### PR TITLE
fix(grid): infinite loop in col/row insert; Grid mode reparenting

### DIFF
--- a/createWidget.py
+++ b/createWidget.py
@@ -96,32 +96,36 @@ def reparentWidget(pythonName, w):
     # NAME: int = 0 PARENT: int = 1 WIDGET: int = 2 CHILDREN: int = 3
     nl = findPythonWidgetNameList(pythonName)
     log.debug("w %s baseRoot %s", w, createWidget.baseRoot)
+
+    # Remove this widget from its current parent's children list first.
+    for nl1 in createWidget.widgetNameList:
+        if pythonName in nl1[CHILDREN] and nl1[WIDGET] is not w:
+            nl1[CHILDREN].remove(pythonName)
+
     if str(w) == str(createWidget.baseRoot):
-        nl[PARENT] = myVars.rootWidgetName
-        # remove pythonName out of any childen
-        for nl1 in createWidget.widgetNameList:
-            log.info("nl1 %s", nl1)
-            if pythonName in nl1[CHILDREN]:
-                nl1[CHILDREN].remove(pythonName)
+        # Re-parenting back to the root canvas/frame
+        if nl:
+            nl[PARENT] = myVars.rootWidgetName
         return
+
     if nl:
-        # Replace the parent
-        ParentName = ""
+        # Find the new parent in widgetNameList by widget object identity
         found = False
         for nl2 in createWidget.widgetNameList:
-            # print(nl)
-            if nl2[WIDGET] == w:
-                ParentName = nl2[NAME]
-                # Check if the child is already there
+            if nl2[WIDGET] is w:
+                new_parent_name = nl2[NAME]
                 if pythonName not in nl2[CHILDREN]:
                     nl2[CHILDREN].append(pythonName)
+                nl[PARENT] = new_parent_name
                 found = True
                 break
         if not found:
-            log.error("Unable to locate widget ->%s<-", str(w))
-            # log.error("createWidget.widgetNameList %s", str(createWidget.widgetNameList))
-        else:
-            nl[PARENT] = ParentName
+            # w is not a tracked widget (e.g. geomWidgetFrame itself) —
+            # treat as root-level.
+            log.debug(
+                "reparentWidget: %s not in widgetNameList, treating as root", str(w)
+            )
+            nl[PARENT] = myVars.rootWidgetName
 
 
 def deleteWidgetFromLists(pythonName, widget):
@@ -398,20 +402,70 @@ class createWidget:
                         return w
         return self.root
 
+    def _find_grid_container(self):
+        """Return the smallest container sibling whose screen bbox encloses this
+        widget's centre, or None if no container qualifies.
+
+        Used by reParent() in Grid/Pack mode to auto-detect the target parent
+        when the user clicks Re-Parent without specifying one explicitly.
+        """
+        cx = self.widget.winfo_rootx() + self.widget.winfo_width()  // 2
+        cy = self.widget.winfo_rooty() + self.widget.winfo_height() // 2
+        best = None
+        best_area = float("inf")
+        for nl in createWidget.widgetNameList:
+            candidate = nl[WIDGET]
+            if candidate is self.widget:
+                continue
+            # Only consider container widget types
+            if not hasattr(candidate, "widgetName"):
+                continue
+            wn = myVars.fixWidgetName(candidate.widgetName).lower()
+            if wn not in ("frame", "labelframe", "panedwindow"):
+                continue
+            try:
+                rx = candidate.winfo_rootx()
+                ry = candidate.winfo_rooty()
+                rw = candidate.winfo_width()
+                rh = candidate.winfo_height()
+            except tk.TclError:
+                continue
+            if rw < 4 or rh < 4:
+                continue
+            if rx <= cx <= rx + rw and ry <= cy <= ry + rh:
+                area = rw * rh
+                if area < best_area:
+                    best_area = area
+                    best = candidate
+        return best
+
     def reParent(self, parentWidget):
         """Re-parent this widget.
 
-        In Place mode the widget is also auto-contained into whichever sibling
-        it physically overlaps.  In Grid/Pack mode we just do a straight
-        reparent into the root (or the supplied parentWidget) because
-        containment is controlled by the user through drag-and-drop.
+        In Place mode the widget is auto-contained into whichever sibling it
+        physically overlaps (pixel bounding-box test).
+        In Grid/Pack mode we find the smallest container Frame/Labelframe whose
+        screen bbox contains this widget's centre point; if none qualifies we
+        re-parent back to the root frame.
         """
         # Record old parent name before reparenting
         nl = findPythonWidgetNameList(self.pythonName)
         old_parent_name = nl[PARENT] if nl else myVars.rootWidgetName
 
         if parentWidget is not None:
+            # Caller supplied an explicit target — use it directly.
             changeParentOfTo(self.widget, parentWidget)
+        elif myVars.geomManager in ("Grid", "Pack"):
+            # Auto-detect: find the innermost container that encloses this widget.
+            target = self._find_grid_container()
+            if target is not None:
+                changeParentOfTo(self.widget, target)
+                parentWidget = target
+            else:
+                # No container found — re-parent to geomWidgetFrame (root frame).
+                # changeParentOfTo handles None → self.root case; pass root here.
+                changeParentOfTo(self.widget, self.root)
+                parentWidget = self.root
         else:
             changeParentOfTo(self.widget, self.root)
             parentWidget = self.root
@@ -426,7 +480,7 @@ class createWidget:
                 )
             )
 
-        # Place mode only: auto-contain into the first sibling that encloses us.
+        # Place mode only: also auto-contain into the first sibling that encloses us.
         if myVars.geomManager != "Place":
             return
 

--- a/pytkquickgui.py
+++ b/pytkquickgui.py
@@ -1775,10 +1775,18 @@ _ADD_MARGIN   = 14  # px — how far from the edge the "+" circles sit
 
 
 def _grid_collect_lines(frame, oc_w, oc_h):
-    """Return (col_xs_sorted, row_ys_sorted) from grid_bbox, capped to overlay size."""
+    """Return (col_xs_sorted, row_ys_sorted) from grid_bbox, capped to overlay size.
+
+    Uses grid_size() to get the configured column/row count so we never loop
+    more times than the grid actually has cells.
+    """
+    try:
+        n_cols, n_rows = frame.grid_size()
+    except tk.TclError:
+        n_cols, n_rows = 0, 0
+
     col_xs = {0}
-    col = 0
-    while col <= 64:
+    for col in range(n_cols):
         try:
             bbox = frame.grid_bbox(col, 0)
         except tk.TclError:
@@ -1791,11 +1799,9 @@ def _grid_collect_lines(frame, oc_w, oc_h):
         col_xs.add(x)
         if w > 0:
             col_xs.add(min(x + w, oc_w))
-        col += 1
 
     row_ys = {0}
-    row = 0
-    while row <= 64:
+    for row in range(n_rows):
         try:
             bbox = frame.grid_bbox(0, row)
         except tk.TclError:
@@ -1808,7 +1814,6 @@ def _grid_collect_lines(frame, oc_w, oc_h):
         row_ys.add(y)
         if h > 0:
             row_ys.add(min(y + h, oc_h))
-        row += 1
 
     return sorted(col_xs), sorted(row_ys)
 
@@ -1923,7 +1928,7 @@ def _grid_insert_col(after_col: int):
     """Insert a new column after *after_col* by splitting its minsize in two."""
     if geomWidgetFrame is None:
         return
-    # Find current minsize of the column being split
+    # Find current pixel width of the column being split via grid_bbox
     try:
         bbox = geomWidgetFrame.grid_bbox(after_col, 0)
         cur_size = bbox[2] if bbox else 60
@@ -1931,33 +1936,26 @@ def _grid_insert_col(after_col: int):
         cur_size = 60
     half = max(20, cur_size // 2)
 
-    # How many columns currently exist?
-    n_cols = 0
-    while True:
-        # Gets into an infinite loop here.....
-        if n_cols > 1000:  # Sanity check
-            log.error("n_cols too big ? n_cols=%d makeing it 5", n_cols)
-            n_cols = 5
-            break
-        try:
-            b = geomWidgetFrame.grid_bbox(n_cols, 0)
-            if b is None:
-                break
-        except tk.TclError:
-            break
-        n_cols += 1
+    # grid_size() returns (cols, rows) — the exact configured grid dimensions.
+    # This avoids polling grid_bbox() in a loop (which never returns None on a
+    # pre-configured frame and caused an infinite loop).
+    try:
+        n_cols, _ = geomWidgetFrame.grid_size()
+    except tk.TclError:
+        n_cols = _CONTAINER_GRID_COLS
     n_cols = max(n_cols, after_col + 2)
 
-    # Shift all columns after the insertion point right by one
+    # Shift all columns after the insertion point right by one, reading each
+    # column's current minsize from columnconfigure before overwriting it.
     for c in range(n_cols, after_col, -1):
         try:
-            src = geomWidgetFrame.grid_bbox(c - 1, 0)
-            src_size = src[2] if src else 60
-        except tk.TclError:
+            info = geomWidgetFrame.columnconfigure(c - 1)
+            src_size = int(info.get("minsize", 60))
+        except (tk.TclError, TypeError, ValueError):
             src_size = 60
         geomWidgetFrame.columnconfigure(c, minsize=src_size, weight=1)
 
-    # Resize the split column and the new one
+    # Resize the split column and the new insertion slot
     geomWidgetFrame.columnconfigure(after_col,     minsize=half, weight=1)
     geomWidgetFrame.columnconfigure(after_col + 1, minsize=half, weight=1)
 
@@ -1976,39 +1974,26 @@ def _grid_insert_row(after_row: int):
         cur_size = 30
     half = max(12, cur_size // 2)
 
-    n_rows = 0
-    while True:
-        try:
-            # Gets into an infinite loop here.....
-            if n_rows > 1000:  # Sanity check
-                log.error("n_rows too big ? n_rows=%d making it 5", n_rows)
-                n_rows = 5
-                break
-            b = geomWidgetFrame.grid_bbox(0, n_rows)
-            if b is None:
-                break
-        except tk.TclError:
-            break
-        n_rows += 1
+    # grid_size() returns (cols, rows) — exact configured dimensions, no loop needed.
+    try:
+        _, n_rows = geomWidgetFrame.grid_size()
+    except tk.TclError:
+        n_rows = _CONTAINER_GRID_ROWS
     n_rows = max(n_rows, after_row + 2)
 
     for r in range(n_rows, after_row, -1):
         try:
-            src = geomWidgetFrame.grid_bbox(0, r - 1)
-            src_size = src[3] if src else 30
-        except tk.TclError:
+            info = geomWidgetFrame.rowconfigure(r - 1)
+            src_size = int(info.get("minsize", 30))
+        except (tk.TclError, TypeError, ValueError):
             src_size = 30
         geomWidgetFrame.rowconfigure(r, minsize=src_size, weight=1)
 
-    log.info("n_rows=%d after_row=%d minsize=%d",n_rows,after_row,half)
     geomWidgetFrame.rowconfigure(after_row,     minsize=half, weight=1)
     geomWidgetFrame.rowconfigure(after_row + 1, minsize=half, weight=1)
 
-    log.info("Before update_idletasks")
     geomWidgetFrame.update_idletasks()
-    log.info("After update_idletasks")
     drawGridLines()
-    log.info("After drawGridLines")
 
 
 def drawGridLines():


### PR DESCRIPTION
## Summary

Two bugs reported after PR #46 testing.

---

### Bug 1 — 100% CPU / infinite loop in `_grid_insert_col` and `_grid_insert_row`

**Root cause:** Both functions counted the number of configured grid columns/rows by calling `grid_bbox(n, 0)` in a `while True` loop and breaking when it returned `None`. On a frame pre-configured with `columnconfigure`/`rowconfigure` for 32 columns and 32 rows, **`grid_bbox()` never returns `None`** — it always returns a valid `(x, y, w, h)` tuple for every configured index. The loop ran to 1000+ before Chris's workaround sanity-cap stopped it.

**Fix:**
- Replaced the counting loops in both `_grid_insert_col` and `_grid_insert_row` with a single `grid_size()` call, which returns `(cols, rows)` directly — no iteration needed.
- Same fix applied to `_grid_collect_lines` (used by `drawGridLines`) which had the same loop pattern with a `<= 64` cap that worked by accident.
- Changed the minsize-shift loop to read `columnconfigure(c-1)` / `rowconfigure(r-1)` directly instead of using `grid_bbox`, removing any remaining bbox dependency.
- Removed Chris's `> 1000` sanity-check workaround and debug `log.info()` calls — no longer needed.

---

### Bug 2 — Re-parenting in Grid mode: widget stays attached to root

**Root cause A:** `reParent(None)` always passed `self.root` (the main canvas) to `changeParentOfTo()`. There was no logic to find a target container Frame — the widget just got re-parented to the root unconditionally.

**Fix:** Added `_find_grid_container()` method that:
1. Gets the screen centre point of the widget being re-parented.
2. Scans `widgetNameList` for `Frame` / `Labelframe` / `Panedwindow` widgets.
3. Finds the **smallest** (innermost) container whose screen bbox contains the widget's centre.
4. Returns that container, or `None` if none qualifies.

`reParent()` now calls `_find_grid_container()` in Grid/Pack mode and uses the result as the target; falls back to root if no container qualifies.

**Root cause B:** `reparentWidget()` added the widget to the new parent's `CHILDREN` list but **never removed it from the old parent's `CHILDREN` list**, leaving the hierarchy table inconsistent. On the next save/load the widget appeared under both parents.

**Fix:** `reparentWidget()` now removes `pythonName` from every other entry's `CHILDREN` list before updating `PARENT`. Also added a graceful fallback when the target widget is not in `widgetNameList` (e.g. `geomWidgetFrame` itself): treats the widget as root-level instead of logging an error and leaving `PARENT` unchanged.

---

### Files changed

| File | Changes |
|------|---------|
| `pytkquickgui.py` | `_grid_collect_lines`: use `grid_size()` loop bound; `_grid_insert_col/row`: replace bbox loop with `grid_size()`, read minsize via `columnconfigure/rowconfigure`; remove debug logging |
| `createWidget.py` | `_find_grid_container()`: new method; `reParent()`: Grid/Pack mode uses `_find_grid_container()`; `reparentWidget()`: removes from old parent children list, graceful fallback for untracked parents |