### PR TITLE
Stabilize Grid geometry and JSON project persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ PyTkQuickGui lets you lay out tkinter widgets by dragging, resizing, and editing
 | Feature | Details |
 |---|---|
 | **Visual layout** | Drag, resize and re-parent widgets on a live canvas |
-| **Geometry managers** | Choose **Place**, **Grid**, or **Pack** per project via the toolbar |
+| **Geometry managers** | Choose **Place** or **Grid** when creating a project; **Pack** is intentionally disabled for now |
 | **ttkbootstrap widgets** | Label, Button, Entry, Combobox, Spinbox, Checkbutton, Radiobutton, Scale, Progressbar, Floodgauge, Meter, Notebook, Canvas, Frame, Labelframe, Panedwindow |
 | **Standard tk/ttk widgets** | Text, Listbox, Treeview, Scrollbar, Separator, Sizegrip |
 | **Widget editor** | Edit every configurable attribute through generated combo/spinbox/entry controls |
@@ -197,7 +197,7 @@ When you release a widget on top of a container (Frame, Labelframe, etc.), the t
 
 ## Geometry Managers
 
-PyTkQuickGui supports all three Tk geometry managers.  Select the one you want from the **toolbar** before placing widgets – the setting is saved with the project.
+PyTkQuickGui currently supports **Place** and **Grid**. Choose the manager when creating a project; the setting is saved with the project.
 
 ### Place (default)
 Widgets are positioned with absolute `x`, `y`, `width`, `height` coordinates.  Best for pixel-perfect layouts and quick prototyping.
@@ -207,20 +207,14 @@ myWidget.place(x=80, y=40, width=120, height=28, anchor='nw', bordermode='inside
 ```
 
 ### Grid
-Widgets snap to a row/column grid.  Dropping a widget calculates the nearest grid cell.  Generated code uses `grid(row=…, column=…, sticky=…, padx=…, pady=…)`.  Best for forms and tables.
+Widgets snap to a row/column grid. Dragging across container boundaries recalculates the cell in the target container, and edge drags adjust row/column spans. Generated code configures the required rows and columns before using `grid(row=…, column=…, sticky=…, padx=…, pady=…)`. Best for responsive forms and tables.
 
 ```python
 myWidget.grid(row=1, column=2, sticky='WE', padx=2, pady=2)
 ```
 
 ### Pack
-Widgets are stacked sequentially.  Dragging and dropping still places widgets, but the pack order is determined by creation order.  Generated code uses `pack(side=…, fill=…, expand=…)`.  Best for simple vertical or horizontal stacks.
-
-```python
-myWidget.pack(side='top', fill='none', expand=0, padx=4, pady=4)
-```
-
-> **Tip:** You can change the geometry manager at any time during design.  The saved project records which manager was active so reloading restores it automatically.
+Pack remains experimental and cannot be selected for a new project. Its existing code is retained for compatibility with old project files, but work on Pack is deferred until Place and Grid are stable.
 
 ---
 
@@ -240,6 +234,7 @@ Projects are stored as plain **JSON** files in `~/.config/pytkgui/<ProjectName>/
 ### File structure (excerpt)
 ```json
 {
+  "formatVersion": 2,
   "ProjectName": "MyProject",
   "theme": "cyborg",
   "geomManager": "Place",
@@ -265,6 +260,8 @@ Projects saved by older versions of PyTkQuickGui used Python's `pickle` format (
 3. A one-time info dialog tells you the file was loaded from the legacy format and will be re-saved as JSON on next save.
 
 > **Warning:** Hand-editing JSON is powerful but risky.  An invalid JSON file will prevent the project from loading.  Keep a backup copy before editing.
+
+Project writes are validated and atomically replace the current JSON file. Callback and Tk-variable names (`command`, `postcommand`, `textvariable`, and `variable`) are stored as design-time strings so they survive save, reload, duplicate, and subsequent saves without being replaced by Tk's internal Tcl identifiers.
 
 ---
 
@@ -380,7 +377,7 @@ Popular themes: `cosmo`, `flatly`, `journal`, `litera`, `lumen`, `minty`, `pulse
 * **Meter widget** – the ttkbootstrap `Meter` widget has some quirks when used inside containers; if it does not display correctly, try running a Trial Run and see how it looks in the generated app.
 * **Scrollbar attachment** – automatic scrollbar wiring (via the Edit → `vertical_scrollbar` / `horizontal_scrollbar` controls) currently works only with the **Grid** manager.
 * **Notebook tabs** – tab count is set in the Edit popup; individual tab frames need to be re-parented manually.
-* **Pack ordering** – in Pack mode, widget draw-order follows creation order, not drag position.  Re-ordering requires editing the generated code.
+* **Pack geometry** – Pack is intentionally disabled for new projects while its interaction model is redesigned.
 * **No undo** – accidental deletions cannot be undone from the GUI; use *File ▸ Open backup file* to recover from a save point.
 
 ---

--- a/createWidget.py
+++ b/createWidget.py
@@ -8,8 +8,10 @@ from typing import Any
 import ttkbootstrap as ttk
 
 import editWidget as ew
+import project_format
 import pytkguivars as myVars
 import undoredo
+from layout_model import GridGeometry
 
 string1: Any
 string2: Any
@@ -64,6 +66,8 @@ def snapToClosest(v: int) -> int:
 
 
 def findPythonWidgetNameFromWidget(widget) -> str:
+    if str(widget) == str(createWidget.baseRoot):
+        return myVars.rootWidgetName
     found: bool = False
     # [pythonName, parentName, widget, [children, ...]])
     # NAME: int = 0 PARENT: int = 1 WIDGET: int = 2 CHILDREN: int = 3
@@ -232,32 +236,35 @@ def changeParentOfTo(widget, newParentWidget):
 
     mgr = myVars.geomManager
     if mgr == "Grid":
-        # Preserve grid position if already gridded, else start at 0,0
-        try:
-            gi = widget.grid_info()
-            row = int(gi.get("row", 0))
-            col = int(gi.get("column", 0))
-        except (tk.TclError, TypeError):
-            row, col = 0, 0
-        # Look up cwo for span/sticky
         py_name = findPythonWidgetNameFromWidget(widget)
         cwo = findCreateWidgetObject(py_name) if py_name else None
-        col_span = cwo.columnspan if cwo is not None else 2
-        row_span = cwo.rowspan if cwo is not None else 2
-        sticky = cwo.sticky if cwo is not None else "nsew"
+        if cwo is not None:
+            state = cwo.capture_grid_geometry()
+            parent_name = findPythonWidgetNameFromWidget(newParentWidget)
+            if not parent_name:
+                parent_name = myVars.rootWidgetName
+            cwo.apply_grid_geometry(
+                state.updated(parent=parent_name),
+                parent_widget=newParentWidget,
+            )
+            return
+        # Untracked helper widgets are uncommon; preserve their live settings.
+        try:
+            grid_info = widget.grid_info()
+        except tk.TclError:
+            grid_info = {}
         widget.grid(
             in_=newParentWidget,
-            row=row,
-            column=col,
-            columnspan=col_span,
-            rowspan=row_span,
-            padx=2,
-            pady=2,
-            sticky=sticky,
+            row=int(grid_info.get("row", 0)),
+            column=int(grid_info.get("column", 0)),
+            columnspan=max(1, int(grid_info.get("columnspan", 1))),
+            rowspan=max(1, int(grid_info.get("rowspan", 1))),
+            padx=int(grid_info.get("padx", 2)),
+            pady=int(grid_info.get("pady", 2)),
+            ipadx=int(grid_info.get("ipadx", 0)),
+            ipady=int(grid_info.get("ipady", 0)),
+            sticky=str(grid_info.get("sticky", "nsew")),
         )
-        if cwo is not None:
-            cwo.col = col
-            cwo.row = row
     elif mgr == "Pack":
         widget.pack(in_=newParentWidget, padx=4, pady=4, anchor="nw")
     else:
@@ -342,7 +349,7 @@ class createWidget:
         self.col = 4
         self.columnspan = 1  # number of grid columns this widget spans
         self.rowspan = 1  # number of grid rows    this widget spans
-        self.sticky = ""  # tkinter sticky string — user-controlled (empty = no stretch)
+        self.sticky = "nsew"  # tkinter sticky string — user-controlled
         self.padx = 2  # grid padx  (external padding)
         self.pady = 2  # grid pady  (external padding)
         self.ipadx = 0  # grid ipadx (internal padding / extra width)
@@ -437,6 +444,181 @@ class createWidget:
     def setRoot(self, root):
         createWidget.baseRoot = root
 
+    def _design_root(self):
+        """Return the root geometry container used by designer widgets."""
+        root = createWidget.baseRoot
+        if root is any or root is None:
+            return self.root
+        return root
+
+    def grid_parent_name(self) -> str:
+        nl = findPythonWidgetNameList(self.pythonName)
+        if nl and nl[PARENT]:
+            return nl[PARENT]
+        return myVars.rootWidgetName
+
+    def grid_parent_widget(self):
+        parent_name = self.grid_parent_name()
+        if parent_name != myVars.rootWidgetName:
+            parent_nl = findPythonWidgetNameList(parent_name)
+            if parent_nl:
+                return parent_nl[WIDGET]
+        return self._design_root()
+
+    def capture_grid_geometry(self) -> GridGeometry:
+        """Return the authoritative Grid geometry for this widget."""
+        return GridGeometry(
+            parent=self.grid_parent_name(),
+            row=max(0, int(self.row)),
+            column=max(0, int(self.col)),
+            columnspan=max(1, int(self.columnspan)),
+            rowspan=max(1, int(self.rowspan)),
+            sticky=str(self.sticky),
+            padx=max(0, int(self.padx)),
+            pady=max(0, int(self.pady)),
+            ipadx=max(0, int(self.ipadx)),
+            ipady=max(0, int(self.ipady)),
+        )
+
+    @staticmethod
+    def _configure_grid_extent(parent_widget, state: GridGeometry) -> None:
+        """Ensure newly addressed cells have useful size and resize weight."""
+        try:
+            for col in range(state.column, state.column + state.columnspan):
+                info = parent_widget.columnconfigure(col)
+                minsize = str(info.get("minsize", "0"))
+                if minsize in ("", "0", "0.0"):
+                    parent_widget.columnconfigure(
+                        col,
+                        weight=1,
+                        minsize=myVars.gridColMinsize,
+                        pad=myVars.gridColPad,
+                    )
+            for row in range(state.row, state.row + state.rowspan):
+                info = parent_widget.rowconfigure(row)
+                minsize = str(info.get("minsize", "0"))
+                if minsize in ("", "0", "0.0"):
+                    parent_widget.rowconfigure(
+                        row,
+                        weight=1,
+                        minsize=myVars.gridRowMinsize,
+                        pad=myVars.gridRowPad,
+                    )
+        except (tk.TclError, TypeError, ValueError):
+            # Notebook tab frames and a few ttkbootstrap helper widgets do not
+            # expose a configurable grid.  The grid() call below will report a
+            # useful error if the target genuinely cannot manage the widget.
+            pass
+
+    def apply_grid_geometry(
+        self,
+        state: GridGeometry,
+        parent_widget=None,
+        update_hierarchy: bool = True,
+    ) -> None:
+        """Apply one complete Grid state and keep every representation in sync."""
+        if not isinstance(state, GridGeometry):
+            raise TypeError("state must be a GridGeometry")
+
+        if parent_widget is None:
+            if state.parent != myVars.rootWidgetName:
+                parent_nl = findPythonWidgetNameList(state.parent)
+                parent_widget = parent_nl[WIDGET] if parent_nl else None
+            if parent_widget is None:
+                parent_widget = self._design_root()
+
+        self.row = state.row
+        self.col = state.column
+        self.columnspan = state.columnspan
+        self.rowspan = state.rowspan
+        self.sticky = state.sticky
+        self.padx = state.padx
+        self.pady = state.pady
+        self.ipadx = state.ipadx
+        self.ipady = state.ipady
+
+        try:
+            self.widget.place_forget()
+        except tk.TclError:
+            pass
+        self._configure_grid_extent(parent_widget, state)
+        self.widget.grid(
+            in_=parent_widget,
+            row=state.row,
+            column=state.column,
+            columnspan=state.columnspan,
+            rowspan=state.rowspan,
+            padx=state.padx,
+            pady=state.pady,
+            ipadx=state.ipadx,
+            ipady=state.ipady,
+            sticky=state.sticky,
+        )
+        if update_hierarchy:
+            reparentWidget(self.pythonName, parent_widget)
+        self.widget.parent = parent_widget
+        try:
+            tk.Misc.lift(self.widget, aboveThis=None)
+            parent_widget.update_idletasks()
+        except tk.TclError:
+            pass
+
+    def _is_descendant_name(self, candidate_name: str) -> bool:
+        """Return True when *candidate_name* is below this widget in the tree."""
+        current = candidate_name
+        visited: set[str] = set()
+        while current and current != myVars.rootWidgetName and current not in visited:
+            if current == self.pythonName:
+                return True
+            visited.add(current)
+            nl = findPythonWidgetNameList(current)
+            if not nl:
+                break
+            current = nl[PARENT]
+        return False
+
+    def _find_grid_container_at(self, x_root: int, y_root: int):
+        """Return the smallest valid container containing a screen position."""
+        best = None
+        best_area = float("inf")
+        for nl in createWidget.widgetNameList:
+            candidate_name = nl[NAME]
+            candidate = nl[WIDGET]
+            if candidate is self.widget or self._is_descendant_name(candidate_name):
+                continue
+            if not hasattr(candidate, "widgetName"):
+                continue
+            widget_name = myVars.fixWidgetName(candidate.widgetName).lower()
+            if widget_name not in ("frame", "labelframe", "panedwindow"):
+                continue
+            try:
+                rx = candidate.winfo_rootx()
+                ry = candidate.winfo_rooty()
+                width = candidate.winfo_width()
+                height = candidate.winfo_height()
+            except tk.TclError:
+                continue
+            if width < 4 or height < 4:
+                continue
+            if rx <= x_root <= rx + width and ry <= y_root <= ry + height:
+                area = width * height
+                if area < best_area:
+                    best = candidate
+                    best_area = area
+        return best
+
+    @staticmethod
+    def _grid_location(parent_widget, x_root: int, y_root: int) -> tuple[int, int]:
+        """Convert screen coordinates to a non-negative cell in *parent_widget*."""
+        local_x = max(0, int(x_root) - parent_widget.winfo_rootx())
+        local_y = max(0, int(y_root) - parent_widget.winfo_rooty())
+        try:
+            col, row = parent_widget.grid_location(local_x, local_y)
+        except tk.TclError:
+            col = local_x // 60
+            row = local_y // 30
+        return max(0, int(col)), max(0, int(row))
+
     def lock_as_tab_frame(self):
         """Called when this widget has been added to a notebook as a tab frame.
         Unbinds drag/resize mouse events so the user cannot accidentally move
@@ -507,33 +689,7 @@ class createWidget:
         """
         cx = self.widget.winfo_rootx() + self.widget.winfo_width() // 2
         cy = self.widget.winfo_rooty() + self.widget.winfo_height() // 2
-        best = None
-        best_area = float("inf")
-        for nl in createWidget.widgetNameList:
-            candidate = nl[WIDGET]
-            if candidate is self.widget:
-                continue
-            # Only consider container widget types
-            if not hasattr(candidate, "widgetName"):
-                continue
-            wn = myVars.fixWidgetName(candidate.widgetName).lower()
-            if wn not in ("frame", "labelframe", "panedwindow"):
-                continue
-            try:
-                rx = candidate.winfo_rootx()
-                ry = candidate.winfo_rooty()
-                rw = candidate.winfo_width()
-                rh = candidate.winfo_height()
-            except tk.TclError:
-                continue
-            if rw < 4 or rh < 4:
-                continue
-            if rx <= cx <= rx + rw and ry <= cy <= ry + rh:
-                area = rw * rh
-                if area < best_area:
-                    best_area = area
-                    best = candidate
-        return best
+        return self._find_grid_container_at(cx, cy)
 
     def reParent(self, parentWidget):
         """Re-parent this widget.
@@ -548,10 +704,36 @@ class createWidget:
         nl = findPythonWidgetNameList(self.pythonName)
         old_parent_name = nl[PARENT] if nl else myVars.rootWidgetName
 
+        if myVars.geomManager == "Grid":
+            old_state = self.capture_grid_geometry()
+            target = parentWidget or self._find_grid_container()
+            if target is None:
+                target = self._design_root()
+            target_name = findPythonWidgetNameFromWidget(target)
+            if not target_name:
+                target_name = myVars.rootWidgetName
+            col, row = self._grid_location(
+                target,
+                self.widget.winfo_rootx(),
+                self.widget.winfo_rooty(),
+            )
+            new_state = old_state.updated(
+                parent=target_name,
+                row=row,
+                column=col,
+            )
+            self.apply_grid_geometry(new_state, parent_widget=target)
+            if new_state != old_state:
+                undoredo.stack.push_done(
+                    undoredo.GridMoveCommand(self, old_state, new_state)
+                )
+                myVars.projectSaved = False
+            return
+
         if parentWidget is not None:
             # Caller supplied an explicit target — use it directly.
             changeParentOfTo(self.widget, parentWidget)
-        elif myVars.geomManager in ("Grid", "Pack"):
+        elif myVars.geomManager == "Pack":
             # Auto-detect: find the innermost container that encloses this widget.
             target = self._find_grid_container()
             if target is not None:
@@ -631,7 +813,14 @@ class createWidget:
 
         Returns the new createWidget object.
         """
-        originalName = "Widget" + str(self.widgetId)
+        # Loaded projects may contain non-contiguous IDs. ``pythonName`` is
+        # corrected to the saved ID during load, while the historical numeric
+        # ``widgetId`` field still reflects construction order.
+        originalName = self.pythonName
+        try:
+            source_id = int(originalName.removeprefix("Widget"))
+        except ValueError:
+            source_id = self.widgetId
         origWidgetDict = myVars.saveWidgetAsDict(originalName)
         useDict = origWidgetDict[originalName]
         log.debug("duplicate useDict: %s", useDict)
@@ -648,14 +837,20 @@ class createWidget:
             else:
                 target_parent = self.root
 
-        widgetDef = myVars.buildAWidget(self.widgetId, useDict)
+        widgetDef = myVars.buildAWidget(source_id, useDict)
         log.debug("duplicate widgetDef %s", widgetDef)
-        # Inject target_parent as 'mainFrame' so eval can resolve the name.
+        # Designer widgets share one Tk master and use the geometry manager's
+        # in_= target for logical containment.  Keeping that invariant allows
+        # a cloned child to be dragged back out of its current container.
+        construction_parent = createWidget.baseRoot
+        if construction_parent is any or construction_parent is None:
+            construction_parent = self.root
         widget = eval(  # pylint: disable=eval-used
-            widgetDef, globals(), {"mainFrame": target_parent}
+            widgetDef, globals(), {"mainFrame": construction_parent}
         )
 
-        newW = createWidget(target_parent, widget)
+        newW = createWidget(construction_parent, widget)
+        project_format.remember_preserved_attributes(newW.widget, originalName, useDict)
 
         # Apply geometry appropriate to the current manager
         mgr = myVars.geomManager
@@ -676,23 +871,15 @@ class createWidget:
             # Place the duplicate in the next available cell after this widget's cell
             new_col = max(0, self.col + offsetx)  # offsetx/y are cell offsets in Grid
             new_row = max(0, self.row + offsety)
-            newW.col = new_col
-            newW.row = new_row
-            newW.columnspan = self.columnspan
-            newW.rowspan = self.rowspan
-            newW.sticky = self.sticky
-            newW.padx = self.padx
-            newW.pady = self.pady
-            newW.widget.grid(
-                in_=target_parent,
+            target_name = findPythonWidgetNameFromWidget(target_parent)
+            if not target_name:
+                target_name = myVars.rootWidgetName
+            state = self.capture_grid_geometry().updated(
+                parent=target_name,
                 row=new_row,
                 column=new_col,
-                columnspan=self.columnspan,
-                rowspan=self.rowspan,
-                sticky=self.sticky,
-                padx=self.padx,
-                pady=self.pady,
             )
+            newW.apply_grid_geometry(state, parent_widget=target_parent)
         else:
             # Pack or unknown — fall back to pack
             newW.widget.pack(in_=target_parent, padx=4, pady=4)
@@ -882,6 +1069,16 @@ class createWidget:
         height = self.widget.winfo_height()
         # Save pre-drag state so leftMouseRelease can record undo
         self._pre_drag = (self.x, self.y, width, height)
+        if myVars.geomManager == "Grid":
+            design_root = self._design_root()
+            self._pre_grid_geometry = self.capture_grid_geometry()
+            self._grid_drag_active = False
+            self._grid_drag_origin_px = (
+                self.widget.winfo_rootx() - design_root.winfo_rootx(),
+                self.widget.winfo_rooty() - design_root.winfo_rooty(),
+                width,
+                height,
+            )
         # This should be a configuration param
         jiffyW = 8
         jiffyH = 8
@@ -967,57 +1164,61 @@ class createWidget:
 
         # Grid mode: edge-drags resize the span; centre-drag moves the widget.
         if myVars.geomManager == "Grid":
-            origin = getattr(
+            self._grid_drag_active = True
+            design_root = self._design_root()
+            origin_x, origin_y, origin_w, origin_h = getattr(
                 self,
-                "_span_drag_origin",
+                "_grid_drag_origin_px",
                 (
-                    self.col,
-                    self.row,
-                    self.columnspan,
-                    self.rowspan,
-                    self.x,
-                    self.y,
+                    self.widget.winfo_rootx() - design_root.winfo_rootx(),
+                    self.widget.winfo_rooty() - design_root.winfo_rooty(),
                     width,
                     height,
                 ),
             )
-            _oc, _or, _ocs, _ors, ox, oy, ow, oh = origin
+            pointer_x = event.x_root - design_root.winfo_rootx()
+            pointer_y = event.y_root - design_root.winfo_rooty()
             if self.dragType == "dragEast":
-                # Stretch right edge rightward; left anchor stays fixed at ox
-                cur_right = self.widget.winfo_x() + width + int(deltaX)
-                new_w = max(16, cur_right - ox)
-                self.widget.place(x=ox, y=oy, width=new_w, height=oh)
+                new_x = origin_x
+                new_y = origin_y
+                new_w = max(16, pointer_x - origin_x)
+                new_h = origin_h
             elif self.dragType == "dragSouth":
-                # Stretch bottom edge downward; top anchor stays fixed at oy
-                cur_bottom = self.widget.winfo_y() + height + int(deltaY)
-                new_h = max(16, cur_bottom - oy)
-                self.widget.place(x=ox, y=oy, width=ow, height=new_h)
+                new_x = origin_x
+                new_y = origin_y
+                new_w = origin_w
+                new_h = max(16, pointer_y - origin_y)
             elif self.dragType == "dragWest":
-                # Stretch left edge leftward; right anchor stays fixed at ox+ow
-                right_edge = ox + ow
-                cur_left = self.widget.winfo_x() + int(deltaX)
-                new_x = min(max(0, cur_left), right_edge - 16)
+                right_edge = origin_x + origin_w
+                new_x = min(max(0, pointer_x), right_edge - 16)
+                new_y = origin_y
                 new_w = max(16, right_edge - new_x)
-                self.widget.place(x=new_x, y=oy, width=new_w, height=oh)
+                new_h = origin_h
             elif self.dragType == "dragNorth":
-                # Stretch top edge upward; bottom anchor stays fixed at oy+oh
-                bottom_edge = oy + oh
-                cur_top = self.widget.winfo_y() + int(deltaY)
-                new_y = min(max(0, cur_top), bottom_edge - 16)
+                bottom_edge = origin_y + origin_h
+                new_x = origin_x
+                new_y = min(max(0, pointer_y), bottom_edge - 16)
+                new_w = origin_w
                 new_h = max(16, bottom_edge - new_y)
-                self.widget.place(x=ox, y=new_y, width=ow, height=new_h)
             else:
-                # Centre-drag: float the whole widget
-                newX = self.widget.winfo_x() + int(deltaX)
-                newY = self.widget.winfo_y() + int(deltaY)
-                self.x = max(0, newX)
-                self.y = max(0, newY)
-                self.widget.place(
-                    x=self.x,
-                    y=self.y,
-                    width=self.widget.winfo_width(),
-                    height=self.widget.winfo_height(),
-                )
+                # Float relative to the design root, not the logical parent.
+                # This lets a widget cross container boundaries without its
+                # coordinates jumping between unrelated grids.
+                new_x = max(0, pointer_x - self.startX)
+                new_y = max(0, pointer_y - self.startY)
+                new_w = origin_w
+                new_h = origin_h
+            self.x = new_x
+            self.y = new_y
+            self.width = new_w
+            self.height = new_h
+            self.widget.place(
+                in_=design_root,
+                x=new_x,
+                y=new_y,
+                width=new_w,
+                height=new_h,
+            )
             self.lastX = x
             self.lastY = y
             return
@@ -1093,10 +1294,22 @@ class createWidget:
 
         self._last_drag_type = self.dragType  # read before clearing
         self.dragType = ""
-        newX = snapToClosest(self.x)
-        newY = snapToClosest(self.y)
-        newWidth = snapToClosest(self.widget.winfo_width())
-        newHeight = snapToClosest(self.widget.winfo_height())
+        if myVars.geomManager == "Grid":
+            if not getattr(self, "_grid_drag_active", False):
+                self.x, self.y, self.width, self.height = getattr(
+                    self,
+                    "_grid_drag_origin_px",
+                    (self.x, self.y, self.width, self.height),
+                )
+            newX = int(self.x)
+            newY = int(self.y)
+            newWidth = int(self.width)
+            newHeight = int(self.height)
+        else:
+            newX = snapToClosest(self.x)
+            newY = snapToClosest(self.y)
+            newWidth = snapToClosest(self.widget.winfo_width())
+            newHeight = snapToClosest(self.widget.winfo_height())
         self.x = newX
         self.y = newY
         if newWidth < 16:
@@ -1108,114 +1321,79 @@ class createWidget:
         if myVars.geomManager == "Place":
             self.widget.place(x=self.x, y=self.y, height=self.height, width=self.width)
         elif myVars.geomManager == "Grid":
-            # Widget may be floating via .place() from drag — snap back to grid.
             drag_type = getattr(self, "_last_drag_type", "")
-            origin = getattr(
-                self,
-                "_span_drag_origin",
-                (
-                    self.col,
-                    self.row,
-                    self.columnspan,
-                    self.rowspan,
-                    self.x,
-                    self.y,
-                    self.width,
-                    self.height,
-                ),
+            drag_active = getattr(self, "_grid_drag_active", False)
+            old_state = getattr(
+                self, "_pre_grid_geometry", self.capture_grid_geometry()
             )
-            anc_col, anc_row, _ocs, _ors, _ox, _oy, _ow, _oh = origin
-            try:
-                self.widget.place_forget()
-            except tk.TclError:
-                pass
-            try:
-                if drag_type == "dragEast":
-                    # Right edge dragged: anchor col unchanged, span = cols crossed
-                    right_x = self.widget.winfo_x() + self.widget.winfo_width()
-                    z_end = self.root.grid_location(right_x - 1, self.widget.winfo_y())
-                    end_col = max(anc_col, int(z_end[0]))
-                    self.col = anc_col
-                    self.columnspan = max(1, end_col - anc_col + 1)
-                    self.row = anc_row
-                    self.rowspan = _ors
-                elif drag_type == "dragSouth":
-                    # Bottom edge dragged: anchor row unchanged, span = rows crossed
-                    bot_y = self.widget.winfo_y() + self.widget.winfo_height()
-                    z_end = self.root.grid_location(self.widget.winfo_x(), bot_y - 1)
-                    end_row = max(anc_row, int(z_end[1]))
-                    self.row = anc_row
-                    self.rowspan = max(1, end_row - anc_row + 1)
-                    self.col = anc_col
-                    self.columnspan = _ocs
-                elif drag_type == "dragWest":
-                    # Left edge dragged: right col fixed, new start col moves left
-                    right_col = anc_col + _ocs - 1
-                    z_start = self.root.grid_location(
-                        self.widget.winfo_x(), self.widget.winfo_y()
-                    )
-                    new_col = min(max(0, int(z_start[0])), right_col)
-                    self.col = new_col
-                    self.columnspan = max(1, right_col - new_col + 1)
-                    self.row = anc_row
-                    self.rowspan = _ors
-                elif drag_type == "dragNorth":
-                    # Top edge dragged: bottom row fixed, new start row moves up
-                    bot_row = anc_row + _ors - 1
-                    z_start = self.root.grid_location(
-                        self.widget.winfo_x(), self.widget.winfo_y()
-                    )
-                    new_row = min(max(0, int(z_start[1])), bot_row)
-                    self.row = new_row
-                    self.rowspan = max(1, bot_row - new_row + 1)
-                    self.col = anc_col
-                    self.columnspan = _ocs
-                else:
-                    # Centre-drag: move to the cell under the widget's top-left.
-                    # Preserve existing columnspan/rowspan — only position changes.
-                    z = self.root.grid_location(self.x, self.y)
-                    self.row = max(0, int(z[1]))
-                    self.col = max(0, int(z[0]))
-                    self.columnspan = _ocs
-                    self.rowspan = _ors
-            except (tk.TclError, TypeError, ValueError):
-                pass
-            # self.sticky / self.padx / self.pady are the authoritative values —
-            # set by applyLayoutSettings or initialised in __init__.
-            # Do NOT read grid_info() here: the widget may still be floating
-            # via .place() and grid_info() would return stale or empty data.
-            #
-            # IMPORTANT: include in_= so the widget re-grids into its CURRENT
-            # recorded parent (which may be a container Frame), not back to
-            # self.root.  Without in_=, tkinter defaults to the widget's master
-            # which re-parents it to root and loses all reparenting work.
-            _nl = findPythonWidgetNameList(self.pythonName)
-            _grid_parent = self.root
-            if _nl and _nl[PARENT] != myVars.rootWidgetName:
-                _parent_nl = findPythonWidgetNameList(_nl[PARENT])
-                if _parent_nl:
-                    _grid_parent = _parent_nl[WIDGET]
-            self.widget.grid(
-                in_=_grid_parent,
-                row=self.row,
-                column=self.col,
-                columnspan=self.columnspan,
-                rowspan=self.rowspan,
-                padx=self.padx,
-                pady=self.pady,
-                ipadx=self.ipadx,
-                ipady=self.ipady,
-                sticky=self.sticky,
-            )
+            design_root = self._design_root()
+            root_x = design_root.winfo_rootx()
+            root_y = design_root.winfo_rooty()
+            left_root = root_x + self.x
+            top_root = root_y + self.y
+            right_root = left_root + max(1, self.width) - 1
+            bottom_root = top_root + max(1, self.height) - 1
+
+            # Resizing stays in the current parent. A centre drag may cross a
+            # container boundary and is automatically re-parented on release.
+            if drag_type or not drag_active:
+                target = self.grid_parent_widget()
+                target_name = old_state.parent
+            else:
+                centre_x = left_root + max(1, self.width) // 2
+                centre_y = top_root + max(1, self.height) // 2
+                target = self._find_grid_container_at(centre_x, centre_y)
+                if target is None:
+                    target = design_root
+                target_name = findPythonWidgetNameFromWidget(target)
+                if not target_name:
+                    target_name = myVars.rootWidgetName
+
+            start_col, start_row = self._grid_location(target, left_root, top_root)
+            end_col, end_row = self._grid_location(target, right_root, bottom_root)
+
+            if not drag_active:
+                new_state = old_state
+            elif drag_type == "dragEast":
+                new_state = old_state.updated(
+                    parent=target_name,
+                    columnspan=max(1, end_col - old_state.column + 1),
+                )
+            elif drag_type == "dragSouth":
+                new_state = old_state.updated(
+                    parent=target_name,
+                    rowspan=max(1, end_row - old_state.row + 1),
+                )
+            elif drag_type == "dragWest":
+                right_col = old_state.column + old_state.columnspan - 1
+                new_col = min(start_col, right_col)
+                new_state = old_state.updated(
+                    parent=target_name,
+                    column=new_col,
+                    columnspan=max(1, right_col - new_col + 1),
+                )
+            elif drag_type == "dragNorth":
+                bottom_row = old_state.row + old_state.rowspan - 1
+                new_row = min(start_row, bottom_row)
+                new_state = old_state.updated(
+                    parent=target_name,
+                    row=new_row,
+                    rowspan=max(1, bottom_row - new_row + 1),
+                )
+            else:
+                new_state = old_state.updated(
+                    parent=target_name,
+                    row=start_row,
+                    column=start_col,
+                )
+
+            self.apply_grid_geometry(new_state, parent_widget=target)
             log.debug(
-                "Left Mouse Release -- col=%s row=%s cspan=%s rspan=%s sticky=%s",
-                self.col,
-                self.row,
-                self.columnspan,
-                self.rowspan,
-                self.sticky,
+                "Grid release %s: %s -> %s",
+                self.pythonName,
+                old_state,
+                new_state,
             )
-            # Redraw grid lines so they reflect the updated cell boundaries
             if myVars.redrawGridLines is not None:
                 self.widget.after_idle(myVars.redrawGridLines)
         elif myVars.geomManager == "Pack":
@@ -1270,9 +1448,17 @@ class createWidget:
             log.error("Geometry Manager %s is TBD", myVars.geomManager)
         raiseChildren(self.pythonName)
 
-        # Record the move/resize as an undoable action (only if something changed)
-        nx, ny, nw, nh = self.x, self.y, self.width, self.height
-        if (ox, oy, ow, oh) != (nx, ny, nw, nh):
+        # Record the move/resize as an undoable action.
+        if myVars.geomManager == "Grid":
+            if old_state != new_state:
+                undoredo.stack.push_done(
+                    undoredo.GridMoveCommand(self, old_state, new_state)
+                )
+                myVars.projectSaved = False
+        else:
+            nx, ny, nw, nh = self.x, self.y, self.width, self.height
+            if (ox, oy, ow, oh) == (nx, ny, nw, nh):
+                return
             undoredo.stack.push_done(
                 undoredo.MoveCommand(self, ox, oy, ow, oh, nx, ny, nw, nh)
             )

--- a/editWidget.py
+++ b/editWidget.py
@@ -10,6 +10,7 @@ from tkfontchooser import askfont
 from ttkbootstrap.dialogs.colorchooser import ColorChooserDialog
 
 import createWidget as cw
+import project_format
 import pytkguivars as myVars
 import undoredo
 
@@ -313,7 +314,10 @@ class widgetEditPopup:
                 ipadx = int(self.stringDict.get("ipadx", 0))
                 ipady = int(self.stringDict.get("ipady", 0))
                 sticky = str(self.stringDict.get("sticky", "nsew"))
-                self.widget.grid(
+                if cwo is None:
+                    raise ValueError(f"no createWidget object for {self.widgetName}")
+                old_state = cwo.capture_grid_geometry()
+                state = old_state.updated(
                     row=row,
                     column=col,
                     columnspan=columnspan,
@@ -324,16 +328,12 @@ class widgetEditPopup:
                     ipady=ipady,
                     sticky=sticky,
                 )
-                if cwo:
-                    cwo.row = row
-                    cwo.col = col
-                    cwo.columnspan = columnspan
-                    cwo.rowspan = rowspan
-                    cwo.sticky = sticky
-                    cwo.padx = padx
-                    cwo.pady = pady
-                    cwo.ipadx = ipadx
-                    cwo.ipady = ipady
+                cwo.apply_grid_geometry(state)
+                if state != old_state:
+                    undoredo.stack.push_done(
+                        undoredo.GridMoveCommand(cwo, old_state, state)
+                    )
+                    myVars.projectSaved = False
                 log.debug(
                     logString,
                     "grid",
@@ -421,6 +421,13 @@ class widgetEditPopup:
                 newVal = self.stringDict.get(k)
                 if newVal == "None" or newVal is None:
                     newVal = ""
+                if k in project_format.PRESERVED_STRING_KEYS:
+                    oldVal = project_format.preserved_widget_value(
+                        self.widget, k, oldVal
+                    )
+                    # Always refresh the explicit design-time value.  This is
+                    # intentionally independent of Tk's transformed cget().
+                    project_format.remember_widget_value(self.widget, k, newVal)
                 if oldVal != newVal:
                     log.debug(
                         "Widget %s Key %s old ->%s<- new ->%s<-",
@@ -467,14 +474,12 @@ class widgetEditPopup:
                             # user-supplied name.  Save the raw string directly
                             # on the widget object so saveWidgetAsDict() can
                             # recover it without going through Tkinter.
-                            if k in ("command", "postcommand",
-                                     "textvariable", "variable"):
-                                if not hasattr(self.widget, "_user_attrs"):
-                                    self.widget._user_attrs = {}
-                                self.widget._user_attrs[k] = str(newVal)
+                            if k in project_format.PRESERVED_STRING_KEYS:
                                 log.info(
                                     "saved user attr %s=%s on %s",
-                                    k, newVal, self.widget
+                                    k,
+                                    newVal,
+                                    self.widget,
                                 )
                         except tk.TclError as e:
                             log.error(e)
@@ -1190,6 +1195,7 @@ class widgetEditPopup:
                 val = child_widget.cget(k)
             else:
                 val = self.widget.cget(k)
+                val = project_format.preserved_widget_value(self.widget, k, val)
             l1 = ttk.Label(scrollContent, text=k)
             uniqueName = k + str(row)
             if k in ignoredKeys:

--- a/layout_model.py
+++ b/layout_model.py
@@ -1,0 +1,150 @@
+"""Geometry records shared by the designer, persistence, and undo/redo.
+
+Tkinter's ``grid_info()`` describes the geometry manager's current state, but
+PyTkQuickGui temporarily switches a widget to ``place()`` while it is dragged.
+During that interval ``grid_info()`` is empty or stale.  ``GridGeometry`` is
+therefore the authoritative, serialisable Grid state used by every code path.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+
+def _as_int(value: Any, default: int) -> int:
+    """Return a tolerant integer for values read from Tk or legacy JSON."""
+    if value in (None, ""):
+        return default
+    try:
+        # Some Tk values stringify as ``"2 2"``; the first value is the one
+        # older PyTkQuickGui code consistently used.
+        return int(str(value).split()[0])
+    except (TypeError, ValueError):
+        return default
+
+
+@dataclass(frozen=True)
+class GridGeometry:
+    """Complete Grid geometry for one designer widget."""
+
+    parent: str = "rootWidget"
+    row: int = 0
+    column: int = 0
+    columnspan: int = 1
+    rowspan: int = 1
+    sticky: str = "nsew"
+    padx: int = 2
+    pady: int = 2
+    ipadx: int = 0
+    ipady: int = 0
+
+    @classmethod
+    def from_mapping(
+        cls, data: Mapping[str, Any] | None, parent: str = "rootWidget"
+    ) -> GridGeometry:
+        """Build a normalised record from saved ``GeomData``."""
+        values = data or {}
+        return cls(
+            parent=str(parent or "rootWidget"),
+            row=max(0, _as_int(values.get("row"), 0)),
+            column=max(0, _as_int(values.get("column"), 0)),
+            columnspan=max(1, _as_int(values.get("columnspan"), 1)),
+            rowspan=max(1, _as_int(values.get("rowspan"), 1)),
+            sticky=str(values.get("sticky", "nsew") or ""),
+            padx=max(0, _as_int(values.get("padx"), 2)),
+            pady=max(0, _as_int(values.get("pady"), 2)),
+            ipadx=max(0, _as_int(values.get("ipadx"), 0)),
+            ipady=max(0, _as_int(values.get("ipady"), 0)),
+        )
+
+    def updated(self, **changes: Any) -> GridGeometry:
+        """Return a copy with selected fields replaced and normalised."""
+        return GridGeometry.from_mapping(
+            {
+                "row": changes.get("row", self.row),
+                "column": changes.get("column", self.column),
+                "columnspan": changes.get("columnspan", self.columnspan),
+                "rowspan": changes.get("rowspan", self.rowspan),
+                "sticky": changes.get("sticky", self.sticky),
+                "padx": changes.get("padx", self.padx),
+                "pady": changes.get("pady", self.pady),
+                "ipadx": changes.get("ipadx", self.ipadx),
+                "ipady": changes.get("ipady", self.ipady),
+            },
+            parent=str(changes.get("parent", self.parent)),
+        )
+
+    def to_json(self) -> dict[str, str]:
+        """Return the backwards-compatible JSON representation."""
+        return {
+            "row": str(self.row),
+            "column": str(self.column),
+            "columnspan": str(self.columnspan),
+            "rowspan": str(self.rowspan),
+            "sticky": self.sticky,
+            "padx": str(self.padx),
+            "pady": str(self.pady),
+            "ipadx": str(self.ipadx),
+            "ipady": str(self.ipady),
+        }
+
+
+def is_saved_notebook_tab(
+    project_data: Mapping[str, Any], widget_name: str, root_name: str
+) -> bool:
+    """Return whether a saved frame is managed as a Notebook tab."""
+    widget_data = project_data.get(widget_name)
+    if not isinstance(widget_data, Mapping):
+        return False
+    parent_name = str(widget_data.get("WidgetParent", root_name) or root_name)
+    if parent_name == root_name:
+        return False
+    parent_data = project_data.get(parent_name)
+    return (
+        isinstance(parent_data, Mapping)
+        and parent_data.get("WidgetName") == "ttk::notebook"
+        and widget_data.get("WidgetName")
+        in ("ttk::frame", "ttk::labelframe", "frame", "labelframe")
+    )
+
+
+def grid_layout_requirements(
+    project_data: Mapping[str, Any],
+    widget_order: Iterable[str],
+    root_name: str,
+    container_columns: int = 4,
+    container_rows: int = 4,
+) -> dict[str, tuple[int, int]]:
+    """Return ``parent -> (column_count, row_count)`` for generated code."""
+    requirements: dict[str, list[int]] = {
+        root_name: [
+            max(2, _as_int(project_data.get("gridCols"), 10)),
+            max(2, _as_int(project_data.get("gridRows"), 10)),
+        ]
+    }
+    for widget_name in widget_order:
+        if widget_name == root_name:
+            continue
+        widget_data = project_data.get(widget_name)
+        if not isinstance(widget_data, Mapping):
+            continue
+        parent = str(widget_data.get("WidgetParent", root_name) or root_name)
+        state = GridGeometry.from_mapping(widget_data.get("GeomData"), parent=parent)
+        if not is_saved_notebook_tab(project_data, widget_name, root_name):
+            extent = requirements.setdefault(parent, [0, 0])
+            extent[0] = max(extent[0], state.column + state.columnspan)
+            extent[1] = max(extent[1], state.row + state.rowspan)
+        if widget_data.get("WidgetName") in (
+            "ttk::frame",
+            "ttk::labelframe",
+            "ttk::panedwindow",
+        ):
+            container_extent = requirements.setdefault(widget_name, [0, 0])
+            container_extent[0] = max(container_extent[0], container_columns)
+            container_extent[1] = max(container_extent[1], container_rows)
+    return {
+        parent: (max(1, values[0]), max(1, values[1]))
+        for parent, values in requirements.items()
+    }

--- a/project_format.py
+++ b/project_format.py
@@ -1,0 +1,176 @@
+"""Pure helpers for the JSON project format.
+
+Values such as ``command`` are design-time Python names, not live Tk callback
+objects.  Tkinter may transform callback values into internal Tcl command
+names, so these fields must be preserved explicitly rather than reconstructed
+from ``widget.cget()``.
+"""
+
+from __future__ import annotations
+
+import json
+import keyword
+import os
+import shutil
+from collections.abc import Iterable, Iterator, Mapping
+from typing import Any
+
+FORMAT_VERSION = 2
+
+CALLBACK_KEYS = ("command", "postcommand")
+VARIABLE_KEYS = ("textvariable", "variable")
+PRESERVED_STRING_KEYS = CALLBACK_KEYS + VARIABLE_KEYS
+RUNTIME_CALLABLE_KEYS = ("yscrollcommand", "xscrollcommand")
+
+
+def write_project_json(
+    file_name: str,
+    file_type: str,
+    project_data: Mapping[str, Any],
+    backup_count: int = 5,
+) -> str:
+    """Atomically write a validated project and rotate prior versions.
+
+    The live project remains in place until the complete replacement has been
+    written and parsed successfully.  Returns the resulting JSON filename.
+    """
+    current = file_name + file_type
+    temporary = current + ".tmp"
+    backup_staging = current + ".backup-tmp"
+    try:
+        if os.path.isfile(backup_staging):
+            os.unlink(backup_staging)
+        with open(temporary, "w", encoding="utf-8") as handle:
+            json.dump(project_data, handle, indent=2, default=str)
+            handle.flush()
+            os.fsync(handle.fileno())
+        with open(temporary, "r", encoding="utf-8") as handle:
+            json.load(handle)
+
+        if os.path.isfile(current) and backup_count > 0:
+            shutil.copy2(current, backup_staging)
+            for index in range(backup_count, 1, -1):
+                previous = f"{file_name}-save{index - 1}{file_type}"
+                destination = f"{file_name}-save{index}{file_type}"
+                if os.path.isfile(previous):
+                    os.replace(previous, destination)
+            os.replace(backup_staging, f"{file_name}-save1{file_type}")
+        os.replace(temporary, current)
+        return current
+    except (json.JSONDecodeError, TypeError, OSError):
+        for staging_name in (temporary, backup_staging):
+            try:
+                if os.path.isfile(staging_name):
+                    os.unlink(staging_name)
+            except OSError:
+                pass
+        raise
+
+
+def iter_attributes(
+    widget_name: str, widget_data: Mapping[str, Any]
+) -> Iterator[tuple[str, str]]:
+    """Yield saved ``(key, value)`` attributes in their stored order."""
+    try:
+        count = int(widget_data.get(f"{widget_name}-KeyCount", 0))
+    except (TypeError, ValueError):
+        count = 0
+    for index in range(max(0, count)):
+        attribute = widget_data.get(f"Attribute{index}")
+        if not isinstance(attribute, Mapping):
+            continue
+        key = str(attribute.get("Key", ""))
+        if not key:
+            continue
+        yield key, str(attribute.get("Value", ""))
+
+
+def attribute_map(widget_name: str, widget_data: Mapping[str, Any]) -> dict[str, str]:
+    """Return the last saved value for each attribute key."""
+    return dict(iter_attributes(widget_name, widget_data))
+
+
+def remember_preserved_attributes(
+    widget: Any, widget_name: str, widget_data: Mapping[str, Any]
+) -> None:
+    """Restore raw callback/variable names on a newly rebuilt widget."""
+    saved = attribute_map(widget_name, widget_data)
+    raw = getattr(widget, "_user_attrs", None)
+    if not isinstance(raw, dict):
+        raw = {}
+        widget._user_attrs = raw
+    for key in PRESERVED_STRING_KEYS:
+        if key in saved:
+            raw[key] = saved[key]
+
+
+def preserved_widget_value(widget: Any, key: str, fallback: Any = "") -> Any:
+    """Return a raw design-time value before consulting Tkinter."""
+    raw = getattr(widget, "_user_attrs", {})
+    if key in PRESERVED_STRING_KEYS and isinstance(raw, dict) and key in raw:
+        return raw[key]
+    return fallback
+
+
+def remember_widget_value(widget: Any, key: str, value: Any) -> None:
+    """Store a raw design-time callback or Tk-variable name."""
+    if key not in PRESERVED_STRING_KEYS:
+        return
+    raw = getattr(widget, "_user_attrs", None)
+    if not isinstance(raw, dict):
+        raw = {}
+        widget._user_attrs = raw
+    raw[key] = "" if value is None else str(value)
+
+
+def referenced_names(
+    project_data: Mapping[str, Any],
+    widget_order: Iterable[str],
+    keys: tuple[str, ...],
+    root_name: str,
+) -> list[str]:
+    """Return unique non-empty design names referenced by widget attributes."""
+    found: list[str] = []
+    seen: set[str] = set()
+    for widget_name in widget_order:
+        if widget_name == root_name:
+            continue
+        widget_data = project_data.get(widget_name)
+        if not isinstance(widget_data, Mapping):
+            continue
+        values = attribute_map(widget_name, widget_data)
+        for key in keys:
+            value = values.get(key, "").strip()
+            if value and value not in seen:
+                seen.add(value)
+                found.append(value)
+    return found
+
+
+def valid_python_name(value: str) -> bool:
+    """Return True for a top-level Python identifier suitable for codegen."""
+    return bool(value) and value.isidentifier() and not keyword.iskeyword(value)
+
+
+def callback_names(
+    project_data: Mapping[str, Any], widget_order: Iterable[str], root_name: str
+) -> list[str]:
+    return [
+        name
+        for name in referenced_names(
+            project_data, widget_order, CALLBACK_KEYS, root_name
+        )
+        if valid_python_name(name)
+    ]
+
+
+def variable_names(
+    project_data: Mapping[str, Any], widget_order: Iterable[str], root_name: str
+) -> list[str]:
+    return [
+        name
+        for name in referenced_names(
+            project_data, widget_order, VARIABLE_KEYS, root_name
+        )
+        if valid_python_name(name)
+    ]

--- a/pytkguivars.py
+++ b/pytkguivars.py
@@ -7,6 +7,7 @@ from tkinter import PhotoImage
 import ttkbootstrap as ttk
 
 import createWidget as cw
+import project_format
 
 # import cdefs as C
 # import io
@@ -233,18 +234,15 @@ def saveWidgetAsDict(widgetName) -> dict:
         geomData = {}
         try:
             if geomManager == "Grid":
-                gi = w.grid_info()
-                geomData = {
-                    "row": str(gi.get("row", 0)),
-                    "column": str(gi.get("column", 0)),
-                    "columnspan": str(gi.get("columnspan", 1)),
-                    "rowspan": str(gi.get("rowspan", 1)),
-                    "sticky": str(gi.get("sticky", "nsew")),
-                    "padx": str(gi.get("padx", 2)),
-                    "pady": str(gi.get("pady", 2)),
-                    "ipadx": str(gi.get("ipadx", 0)),
-                    "ipady": str(gi.get("ipady", 0)),
-                }
+                cwo = cw.findCreateWidgetObject(widgetName)
+                if cwo is not None:
+                    geomData = cwo.capture_grid_geometry().to_json()
+                else:
+                    # Compatibility fallback for untracked helper widgets.
+                    gi = w.grid_info()
+                    from layout_model import GridGeometry
+
+                    geomData = GridGeometry.from_mapping(gi).to_json()
             elif geomManager == "Pack":
                 pi = w.pack_info()
                 geomData = {
@@ -289,20 +287,29 @@ def saveWidgetAsDict(widgetName) -> dict:
         # via widget.configure() Tkinter wraps these in Tcl references, making
         # widget["command"] return a mangled string.  editWidget.py saves the
         # raw user string in widget._user_attrs so we can recover it here.
-        _CALLABLE_KEYS = ("yscrollcommand", "xscrollcommand")
-        # command/postcommand: Tkinter mangles these to internal Tcl addresses
-        # when set via widget.configure(), so widget["command"] is NOT the
-        # user-supplied string.  We save them exclusively from widget._user_attrs
-        # which editWidget.py stamps with the raw user string.
-        #
-        # textvariable/variable: Tkinter does NOT mangle these — widget["textvariable"]
-        # reliably returns the variable name the user typed.  So we let these go
-        # through the normal widget[key] path below (no _user_attrs needed).
-        _USER_STRING_KEYS = ("command", "postcommand")
-        # Emit command/postcommand from _user_attrs first (before the key loop).
+        _CALLABLE_KEYS = project_format.RUNTIME_CALLABLE_KEYS
+        # Keep all Python callback and Tk-variable names in explicit design
+        # metadata. This avoids depending on Tk's internal Tcl representation
+        # and gives every save/load/duplicate path the same source of truth.
+        _USER_STRING_KEYS = project_format.PRESERVED_STRING_KEYS
+        # Emit preserved design strings before reading live Tk attributes.
         _user_attrs = getattr(w, "_user_attrs", {})
-        for _ukey, _uval in _user_attrs.items():
-            if _ukey in _USER_STRING_KEYS and _uval:  # skip empty / non-command attrs
+        if not isinstance(_user_attrs, dict):
+            _user_attrs = {}
+        for _ukey in _USER_STRING_KEYS:
+            _uval = _user_attrs.get(_ukey, "")
+            if not _uval:
+                # Compatibility path for widgets created before explicit raw
+                # metadata was introduced. Plain identifiers are safe design
+                # names; Tcl-generated callback handles start with digits.
+                try:
+                    live_value = str(w[_ukey])
+                except (KeyError, tk.TclError):
+                    live_value = ""
+                if project_format.valid_python_name(live_value):
+                    _uval = live_value
+                    project_format.remember_widget_value(w, _ukey, live_value)
+            if _uval:
                 attrId = "Attribute" + str(keyCount)
                 widgetAttribute = {attrId: {"Key": _ukey, "Value": str(_uval)}}
                 newWidget = Merge(widgetDict, widgetAttribute)
@@ -317,7 +324,7 @@ def saveWidgetAsDict(widgetName) -> dict:
                     if key in _CALLABLE_KEYS:
                         log.debug("saveWidgetAsDict: skipping callable key %s", key)
                         continue
-                    # Skip command/postcommand — already emitted from _user_attrs above.
+                    # Skip preserved strings — already emitted from _user_attrs.
                     if key in _USER_STRING_KEYS:
                         log.debug("saveWidgetAsDict: skipping (in _user_attrs) %s", key)
                         continue
@@ -442,7 +449,7 @@ def buildAWidget(widgetId: object, wDictOrig: dict) -> str:
         if len(val) > 0:
             tmpWidgetDef: str = ""
             if useValQuotes:
-                tmpWidgetDef = f"{widgetDef},{key}='{val}'"
+                tmpWidgetDef = f"{widgetDef},{key}={val!r}"
                 # tmpWidgetDef = C.sprintf(widgetDef,"%s,%s='%s'",widgetDef,key,val)
             else:
                 tmpWidgetDef = f"{widgetDef},{key}={val}"

--- a/pytkquickgui.py
+++ b/pytkquickgui.py
@@ -20,12 +20,13 @@ from ttkbootstrap.dialogs import Messagebox, Querybox
 
 import cdefs as C
 import createWidget as cw
+import layout_model
+import project_format
 import pytkguivars as myVars
 import undoredo
 
 # from ttkbootstrap.constants import *
 
-defaultGrids = 32
 log = logging.getLogger(name="mylogger")
 
 
@@ -276,7 +277,7 @@ def saveProjectFile(fileName, fileType, projectData):
     """
     if not projectData:
         log.error("projectData is empty. Not saving")
-        return
+        return False
     # Ensure the directory exists (handles the 'tmp' default project case)
     dirName = os.path.dirname(fileName)
     if dirName and not os.path.isdir(dirName):
@@ -285,26 +286,17 @@ def saveProjectFile(fileName, fileType, projectData):
             log.info("Created project directory %s", dirName)
         except OSError as e:
             log.error("Cannot create project directory %s: %s", dirName, e)
-            return
-    ftails = [5, 4, 3, 2, 1]
-    completeFileName = fileName + fileType
-    for t in ftails:
-        testNameA = str(fileName) + str("-save") + str(t) + fileType
-        if os.path.isfile(testNameA):
-            testNameB = fileName + "-save" + str(t + 1) + fileType
-            os.rename(testNameA, testNameB)
-
-    if os.path.isfile(completeFileName):
-        testNameA = fileName + "-save" + str(1) + fileType
-        os.rename(completeFileName, testNameA)
-
+            return False
     try:
-        with open(completeFileName, "w", encoding="utf-8") as f:
-            json.dump(projectData, f, indent=2, default=str)
+        completeFileName = project_format.write_project_json(
+            fileName, fileType, projectData
+        )
         log.info("Project saved as JSON to %s", completeFileName)
-    except (TypeError, OSError) as e:
+        return True
+    except (json.JSONDecodeError, TypeError, OSError) as e:
         log.error("Exception saving JSON %s", str(e))
         log.warning("Error in Project Data \n%s", str(projectData))
+        return False
 
 
 def saveProject():
@@ -314,6 +306,7 @@ def saveProject():
     height = 0  # mainCanvas.winfo_height
     cleanList = createCleanNameList()
     projectData = {
+        "formatVersion": project_format.FORMAT_VERSION,
         "ProjectName": myVars.projectName,
         "ProjectPath": myVars.projectPath,
         "width": width,
@@ -349,7 +342,9 @@ def saveProject():
     myVars.projectDict = projectData
     fileName = myVars.projectFileName
     log.debug("projectFileName ->%s<-", fileName)
-    saveProjectFile(fileName, myVars.fileType, projectData)
+    if not saveProjectFile(fileName, myVars.fileType, projectData):
+        myVars.projectSaved = False
+        return False
     log.debug("projectData %s", projectData)
     # log.warning("projectData %s", projectData)
     myVars.lastProjectSaved = myVars.projectFileName
@@ -363,6 +358,7 @@ def saveProject():
     sys.stdout.close()
     sys.stdout = sys.__stdout__
     mainFrame.config(text=myVars.projectName)
+    return True
 
 
 # ---------------------------------------------------------------------------
@@ -471,12 +467,31 @@ def buildPython() -> str:
     """
     functions = []
     tkvars = []
-    saveProject()
+    if not saveProject():
+        log.error("buildPython: project save failed; generation cancelled")
+        return ""
     runDict = myVars.projectDict
     nWidgets = runDict.get("widgetCount")
     largestWidth = 200
     largestHeight = 200
     createdWidgetOrder = workOutWidgetCreationOrder()
+    functions = project_format.callback_names(
+        runDict, createdWidgetOrder, myVars.rootWidgetName
+    )
+    tkvars = project_format.variable_names(
+        runDict, createdWidgetOrder, myVars.rootWidgetName
+    )
+    grid_requirements = (
+        layout_model.grid_layout_requirements(
+            runDict,
+            createdWidgetOrder,
+            myVars.rootWidgetName,
+            container_columns=_CONTAINER_GRID_COLS,
+            container_rows=_CONTAINER_GRID_ROWS,
+        )
+        if myVars.geomManager == "Grid"
+        else {}
+    )
     log.info("nWidgets %s", nWidgets)
     configPath = getConfigPath()
     fileName = configPath + "/" + "test.py"
@@ -503,46 +518,35 @@ def buildPython() -> str:
         rootName
         + " = ttk.Frame(rootWin, width=40, height=100, relief='ridge', borderwidth=1)"
     )
-    # Create widgets on the rootFrame first
-    # for widgetName in myVars.createdWidgetOrder:
-    # First pass is to get the command and variable names
-    for widgetName in createdWidgetOrder:
-        if widgetName == rootName:
-            continue
-        wDict = runDict.get(widgetName)
-        if wDict is not None:
-            parentName = findWidgetsParent(widgetName)
-            wType = wDict.get("WidgetName")
-            t = myVars.fixWidgetTypeName(wType)
-            wType = t
-            keyCount = widgetName + "-KeyCount"
-            widgetDef = widgetName + " = " + wType + "(" + parentName
-            nKeys = wDict.get(keyCount)
-            for a in range(nKeys):
-                useValQuotes = True
-                attribute = "Attribute" + str(a)
-                aDict = wDict.get(attribute)
-                key = aDict.get("Key")
-                val = aDict.get("Value")
-                if key == "image":
-                    if val > "":
-                        val = str(widgetName) + str(key)
 
-                elif key == "command" or key == "postcommand":
-                    if val > "":
-                        log.info("command ->%s<-", val)
-                        functions.append(val)
-                elif key == "textvariable":
-                    if val > "":
-                        log.info("textvariable ->%s<-", val)
-                        tkvars.append(val)
-                elif key == "variable":
-                    if val > "":
-                        log.info("variable ->%s<-", val)
-                        tkvars.append(val)
-                # else:
-                # if val > "":
-                # log.error("Unknown key ->%s<- ->%s<-",key,val)
+    def _emit_grid_configuration(parent_name: str) -> None:
+        dimensions = grid_requirements.get(parent_name)
+        if not dimensions:
+            return
+        column_count, row_count = dimensions
+        if parent_name == rootName:
+            col_minsize = repr(myVars.gridColMinsize)
+            row_minsize = repr(myVars.gridRowMinsize)
+            col_pad = repr(myVars.gridColPad)
+            row_pad = repr(myVars.gridRowPad)
+        else:
+            col_minsize = "40"
+            row_minsize = "24"
+            col_pad = "0"
+            row_pad = "0"
+        print(f"for _grid_col in range({column_count}):")
+        print(
+            f"    {parent_name}.columnconfigure(_grid_col, weight=1,"
+            f" minsize={col_minsize}, pad={col_pad})"
+        )
+        print(f"for _grid_row in range({row_count}):")
+        print(
+            f"    {parent_name}.rowconfigure(_grid_row, weight=1,"
+            f" minsize={row_minsize}, pad={row_pad})"
+        )
+
+    if myVars.geomManager == "Grid":
+        _emit_grid_configuration(rootName)
     print("")
     print(_SEC_TKVARS)
     for f in myVars.widgetImageFilenames:
@@ -626,6 +630,15 @@ def buildPython() -> str:
                 val = aDict.get("Value")
                 if key in specialKeys:
                     useValQuotes = False
+                if key in project_format.PRESERVED_STRING_KEYS:
+                    if val and not project_format.valid_python_name(val):
+                        log.warning(
+                            "Skipping invalid Python name %s=%r on %s",
+                            key,
+                            val,
+                            widgetName,
+                        )
+                        continue
                 if key == "from":
                     # Bug in tkinter -- no
                     # 'from' is a python keyword
@@ -645,15 +658,19 @@ def buildPython() -> str:
                 if len(val) > 0:
                     # keys are not consistent ...
                     if useValQuotes:
-                        tmpWidgetDef = widgetDef + ", " + key + "='" + val + "'"
+                        tmpWidgetDef = widgetDef + ", " + key + "=" + repr(val)
                     else:
                         if key == "image":
                             val = str(widgetName) + key
                         tmpWidgetDef = widgetDef + ", " + key + "=" + val
                     widgetDef = tmpWidgetDef
             print(widgetDef + ")")
+            if myVars.geomManager == "Grid":
+                _emit_grid_configuration(widgetName)
             geomData = wDict.get("GeomData", {})
-            if myVars.geomManager == "Place":
+            if layout_model.is_saved_notebook_tab(runDict, widgetName, rootName):
+                print(f"{parentName}.add({widgetName}, text='Tab')")
+            elif myVars.geomManager == "Place":
                 place = wDict.get("Place", geomData)
                 x = place.get("x", "0")
                 y = place.get("y", "0")
@@ -759,6 +776,8 @@ def buildPython() -> str:
 
 def runMe():
     fileName = buildPython()
+    if not fileName:
+        return
     log.info("python fileName ->%s<-", fileName)
     cmd = "python3 " + fileName + " &"
     os.system(cmd)
@@ -796,6 +815,12 @@ def generatePython():
 
     # Now build (with preservation) and copy.
     fileName = buildPython()
+    if not fileName:
+        Messagebox.show_error(
+            title="Generate Error",
+            message="The project could not be saved, so Python generation was cancelled.",
+        )
+        return
     try:
         shutil.copy2(fileName, newFile)
         log.info("Generated Python written to %s", newFile)
@@ -869,127 +894,17 @@ def _is_notebook_tab_type(widget):
 
 
 def changeParentOfTo(widgetName, parentName):
-    # find both widgets
+    """Apply the saved logical parent using createWidget's central helper."""
     widgetList = cw.findPythonWidgetNameList(widgetName)
     parentList = cw.findPythonWidgetNameList(parentName)
     if widgetList == [] or parentList == []:
-        log.error("Empty Lists")
+        log.error(
+            "Unable to reparent %s to %s: widget not found", widgetName, parentName
+        )
         return
     widget = widgetList[cw.WIDGET]
     parent = parentList[cw.WIDGET]
-
-    # ------------------------------------------------------------------
-    # Notebook handling — two cases:
-    #   1. widget IS a Frame/LabelFrame → add it as a new tab (.add())
-    #   2. widget is any other type    → place it INSIDE the currently-
-    #      selected tab frame, not as a new tab
-    # ------------------------------------------------------------------
-    parent_wn = getattr(parent, "widgetName", "")
-    if parent_wn == "ttk::notebook":
-        if _is_notebook_tab_type(widget):
-            # Frame/LabelFrame: register as a notebook tab page
-            existing_tabs = list(parent.tabs())
-            if str(widget) not in existing_tabs:
-                try:
-                    parent.add(widget, text="Tab")
-                    log.info(
-                        "changeParentOfTo: added %s as tab of %s",
-                        widgetName,
-                        parentName,
-                    )
-                except tk.TclError as _te:
-                    log.warning("notebook.add(%s): %s", widgetName, _te)
-            widget.parent = parent
-            cw.reparentWidget(widgetName, parent)
-            # Lock drag/resize — tab frames are sized/positioned by the notebook
-            _tab_cwo = cw.findCreateWidgetObject(widgetName)
-            if _tab_cwo is not None:
-                _tab_cwo.lock_as_tab_frame()
-            return
-        else:
-            # Non-frame: route into the currently-selected tab frame instead
-            tab_frame = _notebook_selected_tab_frame(parent)
-            if tab_frame is not None:
-                tab_frame_name = cw.findPythonWidgetNameFromWidget(tab_frame)
-                log.info(
-                    "changeParentOfTo: routing non-frame %s into tab frame %s (%s)",
-                    widgetName,
-                    tab_frame_name,
-                    tab_frame,
-                )
-                if tab_frame_name:
-                    changeParentOfTo(widgetName, tab_frame_name)
-                else:
-                    # tab frame not in our registry — fall through to direct place
-                    log.warning(
-                        "changeParentOfTo: selected tab frame not in widgetNameList; "
-                        "placing %s directly in notebook",
-                        widgetName,
-                    )
-                    widget.place(in_=parent)
-                    widget.parent = parent
-                    cw.reparentWidget(widgetName, parent)
-                return
-            else:
-                log.warning(
-                    "changeParentOfTo: notebook %s has no selected tab; "
-                    "placing %s directly in notebook",
-                    parentName,
-                    widgetName,
-                )
-                widget.place(in_=parent)
-                widget.parent = parent
-                cw.reparentWidget(widgetName, parent)
-                return
-
-    mgr = myVars.geomManager
-    if mgr == "Place":
-        widget.place(in_=parent)
-        widget.parent = parent
-        widget.update()
-    elif mgr == "Grid":
-        # Use the authoritative createWidget object values (row/col/span/sticky)
-        # rather than grid_info() which may still reflect the old container or
-        # the createWidget.__init__ defaults (row=4, col=4).
-        cwo_r = cw.findCreateWidgetObject(widgetName)
-        if cwo_r is not None:
-            row = cwo_r.row
-            col = cwo_r.col
-            col_span = cwo_r.columnspan
-            row_span = cwo_r.rowspan
-            sticky_r = cwo_r.sticky
-            padx_r = cwo_r.padx
-            pady_r = cwo_r.pady
-            ipadx_r = cwo_r.ipadx
-            ipady_r = cwo_r.ipady
-        else:
-            # Fallback: try grid_info() from the current (old) container
-            try:
-                gi = widget.grid_info()
-                row = int(str(gi.get("row", 0)).split()[0])
-                col = int(str(gi.get("column", 0)).split()[0])
-            except (tk.TclError, ValueError):
-                row, col = 0, 0
-            col_span, row_span, sticky_r = 1, 1, ""
-            padx_r, pady_r, ipadx_r, ipady_r = 2, 2, 0, 0
-        widget.grid(
-            in_=parent,
-            row=row,
-            column=col,
-            columnspan=col_span,
-            rowspan=row_span,
-            padx=padx_r,
-            pady=pady_r,
-            ipadx=ipadx_r,
-            ipady=ipady_r,
-            sticky=sticky_r,
-        )
-    elif mgr == "Pack":
-        widget.pack(in_=parent, padx=4, pady=4, anchor="nw")
-    else:
-        log.error("Geometry Manager %s is TBD", mgr)
-    tk.Misc.lift(widget, parent)
-    cw.reparentWidget(widgetName, parent)
+    cw.changeParentOfTo(widget, parent)
 
 
 def setLabelBorderWidth(width):
@@ -1612,24 +1527,10 @@ def loadProject(project, altFileName):
                 except tk.TclError as _ce:
                     log.debug("post-load colour %s=%s ignored: %s", _ck, _cv, _ce)
 
-        # Repopulate _user_attrs for command/postcommand from the saved JSON.
-        # These keys are saved via _user_attrs (because Tkinter mangles the raw
-        # string via widget.configure()) and must be restored here so that
-        # subsequent saves from an already-loaded project still emit them correctly.
-        _cmd_keys = ("command", "postcommand")
-        for _ai in range(_nkeys):
-            _adict = wDict.get("Attribute" + str(_ai))
-            if _adict is None:
-                continue
-            _ck = _adict.get("Key", "")
-            _cv = _adict.get("Value", "")
-            if _ck in _cmd_keys and _cv and not _cv.startswith("<"):
-                if not hasattr(widget, "_user_attrs"):
-                    widget._user_attrs = {}
-                widget._user_attrs[_ck] = _cv
-                log.info(
-                    "load: restored _user_attrs %s=%s on %s", _ck, _cv, widgetId
-                )
+        # Restore raw Python callback and Tk-variable names.  These values are
+        # design metadata; asking Tkinter for them later can return an internal
+        # Tcl command instead of what the user typed.
+        project_format.remember_preserved_attributes(widget, widgetId, wDict)
 
         # In Grid mode, container widgets need their own row/column
         # configuration so child widgets can be reparented into them.
@@ -1638,68 +1539,51 @@ def loadProject(project, altFileName):
             if wn in myVars.containerWidgetsUsed:
                 _configure_container_grid(widget)
 
-            mgr = myVars.geomManager
-            if mgr == "Place":
-                place = wDict.get("Place") or {}
-                if place:
-                    log.debug(place)
-                    w.addPlace(place)
-            elif mgr == "Grid":
-                geomData = wDict.get("GeomData") or {}
-                row = int(geomData.get("row", 0))
-                col = int(geomData.get("column", 0))
-                columnspan = max(1, int(geomData.get("columnspan", 1)))
-                rowspan = max(1, int(geomData.get("rowspan", 1)))
-                # sticky = geomData.get("sticky", "WE")
-                sticky = "NSEW"
-                padx = int(geomData.get("padx", 2))
-                pady = int(geomData.get("pady", 2))
-                ipadx = int(geomData.get("ipadx", 0))
-                ipady = int(geomData.get("ipady", 0))
-                w.row = row
-                w.col = col
-                w.columnspan = columnspan
-                w.rowspan = rowspan
-                w.sticky = sticky
-                w.padx = padx
-                w.pady = pady
-                w.ipadx = ipadx
-                w.ipady = ipady
-                w.widget.grid(
-                    row=row,
-                    column=col,
-                    columnspan=columnspan,
-                    rowspan=rowspan,
-                    sticky=sticky,
-                    padx=padx,
-                    pady=pady,
-                    ipadx=ipadx,
-                    ipady=ipady,
-                )
-            elif mgr == "Pack":
-                geomData = wDict.get("GeomData") or {}
-                side = geomData.get("side", "top")
-                fill = geomData.get("fill", "none")
-                expand = int(geomData.get("expand", 0))
-                padx = int(geomData.get("padx", 4))
-                pady = int(geomData.get("pady", 4))
-                anchor = geomData.get("anchor", "center")
-                w.pack_side = side
-                w.pack_fill = fill
-                w.pack_expand = expand
-                w.pack_padx = padx
-                w.pack_pady = pady
-                w.pack_anchor = anchor
-                w.widget.pack(
-                    side=side,
-                    fill=fill,
-                    expand=expand,
-                    padx=padx,
-                    pady=pady,
-                    anchor=anchor,
-                )
-            else:
-                log.error("Geometry Manager %s unknown", mgr)
+        # Apply the saved geometry for every manager.  This block used to be
+        # indented inside the Grid-only container setup, which meant Place and
+        # Pack projects were rebuilt with createWidget's random defaults.
+        mgr = myVars.geomManager
+        if mgr == "Place":
+            place = wDict.get("Place") or {}
+            if place:
+                log.debug(place)
+                w.addPlace(place)
+        elif mgr == "Grid":
+            state = layout_model.GridGeometry.from_mapping(
+                wDict.get("GeomData"),
+                parent=wDict.get("WidgetParent", myVars.rootWidgetName),
+            )
+            # Parents are linked after every widget has been constructed.  For
+            # now apply the values in the root design frame; the hierarchy pass
+            # below moves the widget into its saved logical container.
+            w.apply_grid_geometry(
+                state.updated(parent=myVars.rootWidgetName),
+                parent_widget=_load_parent,
+            )
+        elif mgr == "Pack":
+            geomData = wDict.get("GeomData") or {}
+            side = geomData.get("side", "top")
+            fill = geomData.get("fill", "none")
+            expand = int(geomData.get("expand", 0))
+            padx = int(geomData.get("padx", 4))
+            pady = int(geomData.get("pady", 4))
+            anchor = geomData.get("anchor", "center")
+            w.pack_side = side
+            w.pack_fill = fill
+            w.pack_expand = expand
+            w.pack_padx = padx
+            w.pack_pady = pady
+            w.pack_anchor = anchor
+            w.widget.pack(
+                side=side,
+                fill=fill,
+                expand=expand,
+                padx=padx,
+                pady=pady,
+                anchor=anchor,
+            )
+        else:
+            log.error("Geometry Manager %s unknown", mgr)
 
     # After loading all widgets, advance the global widgetId counter past the
     # highest saved ID so that new widgets created after load don't collide.
@@ -1709,27 +1593,18 @@ def loadProject(project, altFileName):
             cw.createWidget.widgetId = _max_id + 1
             log.info("load: widgetId counter advanced to %d", cw.createWidget.widgetId)
 
-    # using widgetNameList, set the hierarchy
-    # NAME 0 PARENT 1 WIDGET 2 CHILDREN 3
-    # Process parents before children: sort so parents come first by walking
-    # the list in creation order (workOutWidgetCreationOrder already ensures
-    # parents precede their children when saving, so widgetNameList order is safe).
+    # Rebuild the hierarchy from each widget's canonical WidgetParent.  The
+    # CHILDREN lists are derived data and may be stale in older project files;
+    # processing both directions used to re-parent the same child repeatedly.
     for nl in widgetNameList:
-        # Does this widget have a different Parent or have Children?
-        # The tcl widget names were removed from this list ( nl[WIDGET] )
         name = nl[cw.NAME]
         parent = nl[cw.PARENT]
-        children = nl[cw.CHILDREN]
         if len(name) > 2:
-            log.debug("name %s parent %s children %s", name, parent, children)
-            for child in children:
-                log.debug("    %s has a child %s", name, child)
-                changeParentOfTo(child, name)
             if parent != myVars.rootWidgetName:
                 log.debug("%s is the parent of %s", parent, name)
                 changeParentOfTo(name, parent)
         else:
-            log.warning("name %s parent %s children %s", name, parent, children)
+            log.warning("name %s parent %s", name, parent)
             log.warning("widgetNameList %s", str(widgetNameList))
 
     # Grid mode: after reparenting, re-apply the saved grid geometry for every
@@ -1744,54 +1619,30 @@ def loadProject(project, altFileName):
             wDict = runDict.get(name)
             if wDict is None:
                 continue
-            geomData = wDict.get("GeomData") or {}
-            if not geomData:
-                continue
-            nl_live = cw.findPythonWidgetNameList(name)
-            if not nl_live:
-                continue
-            widget = nl_live[cw.WIDGET]
             cwo_g = cw.findCreateWidgetObject(name)
+            if cwo_g is None:
+                continue
             try:
-                row = int(geomData.get("row", 0))
-                col = int(geomData.get("column", 0))
-                columnspan = max(1, int(geomData.get("columnspan", 1)))
-                rowspan = max(1, int(geomData.get("rowspan", 1)))
-                sticky = geomData.get("sticky", "nsew")
-                padx = int(geomData.get("padx", 2))
-                pady = int(geomData.get("pady", 2))
-                ipadx = int(geomData.get("ipadx", 0))
-                ipady = int(geomData.get("ipady", 0))
-                widget.grid(
-                    row=row,
-                    column=col,
-                    columnspan=columnspan,
-                    rowspan=rowspan,
-                    sticky=sticky,
-                    padx=padx,
-                    pady=pady,
-                    ipadx=ipadx,
-                    ipady=ipady,
+                state = layout_model.GridGeometry.from_mapping(
+                    wDict.get("GeomData"),
+                    parent=wDict.get("WidgetParent", myVars.rootWidgetName),
                 )
-                if cwo_g is not None:
-                    cwo_g.row = row
-                    cwo_g.col = col
-                    cwo_g.columnspan = columnspan
-                    cwo_g.rowspan = rowspan
-                    cwo_g.sticky = sticky
-                    cwo_g.padx = padx
-                    cwo_g.pady = pady
-                    cwo_g.ipadx = ipadx
-                    cwo_g.ipady = ipady
-                log.debug(
-                    "load grid re-apply: %s row=%d col=%d cspan=%d rspan=%d",
-                    name,
-                    row,
-                    col,
-                    columnspan,
-                    rowspan,
+                # Notebook tab frames are managed by notebook.add(), not grid().
+                parent_nl = (
+                    cw.findPythonWidgetNameList(state.parent)
+                    if state.parent != myVars.rootWidgetName
+                    else []
                 )
-            except (tk.TclError, ValueError) as _ge:
+                if (
+                    parent_nl
+                    and getattr(parent_nl[cw.WIDGET], "widgetName", "")
+                    == "ttk::notebook"
+                    and _is_notebook_tab_type(cwo_g.widget)
+                ):
+                    continue
+                cwo_g.apply_grid_geometry(state)
+                log.debug("load grid re-apply: %s %s", name, state)
+            except (tk.TclError, ValueError, TypeError) as _ge:
                 log.warning("load grid re-apply %s: %s", name, _ge)
 
     # Place mode: after reparenting, reapply full place geometry for every
@@ -2468,7 +2319,9 @@ def compactGrid() -> None:
     row_map = {old: new for new, old in enumerate(all_rows)}
 
     # Check if anything needs to change.
-    if all(col_map[c] == c for c in all_cols) and all(row_map[r] == r for r in all_rows):
+    if all(col_map[c] == c for c in all_cols) and all(
+        row_map[r] == r for r in all_rows
+    ):
         Messagebox.show_info(
             title="Compact Grid",
             message="Grid is already compact — no unused rows or columns to remove.",
@@ -3032,14 +2885,33 @@ def _configure_container_grid(widget):
     Without this, grid(in_=container) raises a TclError because the container
     has no column/row configuration.
 
-    weight=0 means cells do NOT expand to fill space — the container keeps
-    the size Tkinter naturally assigns it.  Children that want to fill the
-    container can set sticky via the Edit popup.
+    Cells expand with the container so ``sticky='nsew'`` behaves the same in
+    the designer and generated code.
     """
     for c in range(_CONTAINER_GRID_COLS):
-        widget.columnconfigure(c, weight=0, minsize=40)
+        widget.columnconfigure(c, weight=1, minsize=40)
     for r in range(_CONTAINER_GRID_ROWS):
-        widget.rowconfigure(r, weight=0, minsize=24)
+        widget.rowconfigure(r, weight=1, minsize=24)
+
+
+def _configure_root_grid(widget):
+    """Configure exactly the user-requested initial Grid dimensions."""
+    columns = max(2, int(getattr(myVars, "gridCols", 10)))
+    rows = max(2, int(getattr(myVars, "gridRows", 10)))
+    for col in range(columns):
+        widget.columnconfigure(
+            col,
+            weight=1,
+            minsize=myVars.gridColMinsize,
+            pad=myVars.gridColPad,
+        )
+    for row in range(rows):
+        widget.rowconfigure(
+            row,
+            weight=1,
+            minsize=myVars.gridRowMinsize,
+            pad=myVars.gridRowPad,
+        )
 
 
 def _placeNewWidget(w, x: int, y: int, width: int = 72, height: int = 32) -> None:
@@ -3066,31 +2938,35 @@ def _placeNewWidget(w, x: int, y: int, width: int = 72, height: int = 32) -> Non
             else ""
         )
         _is_container = _wname in ("frame", "labelframe", "panedwindow")
-        col_span = 1
-        row_span = 1
+        col_span = 2 if _is_container else 1
+        row_span = 2 if _is_container else 1
         # no auto-expansion — user sets sticky via Edit popup
-        # NOTE if sticky="" the widget is only a pixel or so
-        new_sticky = "NSEW"
-        w.grid(
-            in_=parent,
-            row=row,
-            column=col,
-            columnspan=col_span,
-            rowspan=row_span,
-            padx=2,
-            pady=2,
-            sticky=new_sticky,
-        )
+        new_sticky = "nsew"
         # Sync the authoritative cwo fields so drags and popups see the defaults.
         cwo = cw.findCreateWidgetObject(
             w.pythonName if hasattr(w, "pythonName") else ""
         )
         if cwo is not None:
-            cwo.col = col
-            cwo.row = row
-            cwo.columnspan = col_span
-            cwo.rowspan = row_span
-            cwo.sticky = new_sticky
+            state = cwo.capture_grid_geometry().updated(
+                parent=myVars.rootWidgetName,
+                row=row,
+                column=col,
+                columnspan=col_span,
+                rowspan=row_span,
+                sticky=new_sticky,
+            )
+            cwo.apply_grid_geometry(state, parent_widget=parent)
+        else:
+            w.grid(
+                in_=parent,
+                row=row,
+                column=col,
+                columnspan=col_span,
+                rowspan=row_span,
+                padx=2,
+                pady=2,
+                sticky=new_sticky,
+            )
         # Re-lower the overlay canvas so it stays behind the new widget
         if _gridOverlayCanvas is not None:
             try:
@@ -3322,11 +3198,7 @@ def buildGrid(rows, cols):
         # Give the inner frame a large initial size so widgets aren't clipped.
         # The canvas create_window will be resized on every <Configure> event.
         geomWidgetFrame.configure(width=1200, height=900)
-        # Allow every column/row to expand so grid cells grow with the frame
-        for c in range(defaultGrids):
-            geomWidgetFrame.columnconfigure(c, weight=1, minsize=60)
-        for r in range(defaultGrids):
-            geomWidgetFrame.rowconfigure(r, weight=1, minsize=30)
+        _configure_root_grid(geomWidgetFrame)
         # Place the frame so it fills the whole canvas
         mainCanvas.create_window(
             0, 0, window=geomWidgetFrame, anchor="nw", tags="geomframe"
@@ -3407,21 +3279,7 @@ def _rebuild_canvas_for_geom():
         geomWidgetFrame = ttk.Frame(mainCanvas)
         # Give the inner frame a large initial size so widgets aren't clipped.
         geomWidgetFrame.configure(width=1200, height=900)
-        # Configure the requested number of rows/cols (default 10×10, auto-expands).
-        # We always configure a wider range (32) so widgets can be placed beyond
-        # the initial grid size; extra cells just have no min-size configured.
-        _n_cols = max(getattr(myVars, "gridCols", 10), 10)
-        _n_rows = max(getattr(myVars, "gridRows", 10), 10)
-        _msc = myVars.gridColMinsize
-        _msr = myVars.gridRowMinsize
-        _padc = myVars.gridColPad
-        _padr = myVars.gridRowPad
-        for c in range(max(_n_cols, defaultGrids)):
-            # _ms = 60 if c < _n_cols else 0
-            geomWidgetFrame.columnconfigure(c, weight=1, minsize=_msc, pad=_padc)
-        for r in range(max(_n_rows, defaultGrids)):
-            # _ms = 30 if r < _n_rows else 0
-            geomWidgetFrame.rowconfigure(r, weight=1, minsize=_msc, pad=_padr)
+        _configure_root_grid(geomWidgetFrame)
         mainCanvas.create_window(
             0, 0, window=geomWidgetFrame, anchor="nw", tags="geomframe"
         )
@@ -3439,8 +3297,7 @@ def _rebuild_canvas_for_geom():
                 tk.Misc.lower(_gridOverlayCanvas)
             drawGridLines()
 
-        # Ignore this for now._resize_geom_frame
-        # mainCanvas.bind("<Configure>", _resize_geom_frame)
+        mainCanvas.bind("<Configure>", _resize_geom_frame)
         cw.createWidget.baseRoot = geomWidgetFrame
     else:
         geomWidgetFrame = None

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""PyTkQuickGui regression tests."""

--- a/tests/test_layout_model.py
+++ b/tests/test_layout_model.py
@@ -1,0 +1,106 @@
+import unittest
+
+import layout_model
+
+
+class GridGeometryTests(unittest.TestCase):
+    def test_legacy_json_is_normalised(self):
+        state = layout_model.GridGeometry.from_mapping(
+            {
+                "row": "3",
+                "column": "4",
+                "columnspan": "0",
+                "rowspan": "-2",
+                "sticky": "ew",
+                "padx": "7",
+                "pady": "",
+            },
+            parent="Widget1",
+        )
+
+        self.assertEqual(state.parent, "Widget1")
+        self.assertEqual((state.row, state.column), (3, 4))
+        self.assertEqual((state.columnspan, state.rowspan), (1, 1))
+        self.assertEqual(state.sticky, "ew")
+        self.assertEqual((state.padx, state.pady), (7, 2))
+
+    def test_updated_state_keeps_unspecified_geometry(self):
+        original = layout_model.GridGeometry(
+            parent="rootWidget",
+            row=2,
+            column=3,
+            columnspan=2,
+            rowspan=4,
+            sticky="nsew",
+            ipadx=5,
+        )
+
+        moved = original.updated(parent="Widget9", row=7, column=8)
+
+        self.assertEqual(moved.parent, "Widget9")
+        self.assertEqual((moved.row, moved.column), (7, 8))
+        self.assertEqual((moved.columnspan, moved.rowspan), (2, 4))
+        self.assertEqual(moved.ipadx, 5)
+        self.assertEqual(original.parent, "rootWidget")
+
+    def test_json_shape_remains_backwards_compatible(self):
+        state = layout_model.GridGeometry(parent="Widget2", row=1, column=2, rowspan=3)
+
+        self.assertEqual(
+            state.to_json(),
+            {
+                "row": "1",
+                "column": "2",
+                "columnspan": "1",
+                "rowspan": "3",
+                "sticky": "nsew",
+                "padx": "2",
+                "pady": "2",
+                "ipadx": "0",
+                "ipady": "0",
+            },
+        )
+
+    def test_generated_grid_extents_cover_nested_spans_but_not_notebook_tabs(self):
+        project = {
+            "gridCols": 3,
+            "gridRows": 2,
+            "Widget0": {
+                "WidgetName": "ttk::frame",
+                "WidgetParent": "rootWidget",
+                "GeomData": {"row": "1", "column": "2", "columnspan": "2"},
+            },
+            "Widget1": {
+                "WidgetName": "ttk::button",
+                "WidgetParent": "Widget0",
+                "GeomData": {"row": "4", "column": "5", "rowspan": "2"},
+            },
+            "Widget2": {
+                "WidgetName": "ttk::notebook",
+                "WidgetParent": "rootWidget",
+                "GeomData": {"row": "0", "column": "0"},
+            },
+            "Widget3": {
+                "WidgetName": "ttk::frame",
+                "WidgetParent": "Widget2",
+                "GeomData": {"row": "99", "column": "99"},
+            },
+        }
+
+        requirements = layout_model.grid_layout_requirements(
+            project,
+            ["rootWidget", "Widget0", "Widget1", "Widget2", "Widget3"],
+            "rootWidget",
+        )
+
+        self.assertEqual(requirements["rootWidget"], (4, 2))
+        self.assertEqual(requirements["Widget0"], (6, 6))
+        self.assertNotIn("Widget2", requirements)
+        self.assertEqual(requirements["Widget3"], (4, 4))
+        self.assertTrue(
+            layout_model.is_saved_notebook_tab(project, "Widget3", "rootWidget")
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_project_format.py
+++ b/tests/test_project_format.py
@@ -1,0 +1,129 @@
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+import project_format
+
+
+def widget_data(attributes):
+    data = {
+        "WidgetName": "ttk::button",
+        "WidgetParent": "rootWidget",
+        "Widget0-KeyCount": len(attributes),
+    }
+    for index, (key, value) in enumerate(attributes):
+        data[f"Attribute{index}"] = {"Key": key, "Value": value}
+    return data
+
+
+class FakeWidget:
+    pass
+
+
+class ProjectFormatTests(unittest.TestCase):
+    def test_callbacks_and_variables_survive_attribute_round_trip(self):
+        data = widget_data(
+            [
+                ("text", "Run"),
+                ("command", "run_report"),
+                ("textvariable", "button_text"),
+            ]
+        )
+        project = {"Widget0": data}
+
+        self.assertEqual(
+            project_format.callback_names(
+                project, ["rootWidget", "Widget0"], "rootWidget"
+            ),
+            ["run_report"],
+        )
+        self.assertEqual(
+            project_format.variable_names(
+                project, ["rootWidget", "Widget0"], "rootWidget"
+            ),
+            ["button_text"],
+        )
+
+        rebuilt = FakeWidget()
+        project_format.remember_preserved_attributes(rebuilt, "Widget0", data)
+        self.assertEqual(rebuilt._user_attrs["command"], "run_report")
+        self.assertEqual(rebuilt._user_attrs["textvariable"], "button_text")
+
+    def test_mangled_or_invalid_callback_is_not_emitted_as_python(self):
+        project = {
+            "Widget0": widget_data(
+                [
+                    ("command", "140234567890callback"),
+                    ("postcommand", "valid_postcommand"),
+                ]
+            )
+        }
+
+        self.assertEqual(
+            project_format.callback_names(project, ["Widget0"], "rootWidget"),
+            ["valid_postcommand"],
+        )
+
+    def test_explicit_raw_value_wins_over_tk_fallback(self):
+        widget = FakeWidget()
+        widget._user_attrs = {"command": "human_readable_name"}
+
+        self.assertEqual(
+            project_format.preserved_widget_value(
+                widget, "command", "140234567890callback"
+            ),
+            "human_readable_name",
+        )
+
+    def test_duplicate_names_are_emitted_once_in_creation_order(self):
+        project = {
+            "Widget0": widget_data([("command", "shared_handler")]),
+            "Widget1": {
+                **widget_data([("command", "shared_handler")]),
+                "Widget1-KeyCount": 1,
+            },
+        }
+
+        self.assertEqual(
+            project_format.callback_names(
+                project, ["Widget0", "Widget1"], "rootWidget"
+            ),
+            ["shared_handler"],
+        )
+
+    def test_atomic_json_writer_keeps_five_previous_versions(self):
+        with tempfile.TemporaryDirectory() as directory:
+            project_name = str(Path(directory) / "Demo")
+            for version in range(7):
+                result = project_format.write_project_json(
+                    project_name,
+                    ".json",
+                    {
+                        "version": version,
+                        "Widget0": widget_data([("command", "run_report")]),
+                    },
+                )
+                self.assertEqual(result, project_name + ".json")
+
+            with open(result, encoding="utf-8") as handle:
+                rebuilt = json.load(handle)
+            self.assertEqual(rebuilt["version"], 6)
+            self.assertEqual(
+                project_format.callback_names(
+                    rebuilt, ["rootWidget", "Widget0"], "rootWidget"
+                ),
+                ["run_report"],
+            )
+            for backup_index, expected_version in enumerate(range(5, 0, -1), start=1):
+                with open(
+                    f"{project_name}-save{backup_index}.json", encoding="utf-8"
+                ) as handle:
+                    self.assertEqual(json.load(handle)["version"], expected_version)
+            self.assertFalse(Path(f"{project_name}-save6.json").exists())
+            self.assertFalse(Path(result + ".tmp").exists())
+            self.assertFalse(Path(result + ".backup-tmp").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_undoredo.py
+++ b/tests/test_undoredo.py
@@ -1,0 +1,39 @@
+import unittest
+
+import undoredo
+from layout_model import GridGeometry
+
+
+class FakeCreateWidget:
+    pythonName = "Widget3"
+
+    def __init__(self):
+        self.applied = []
+
+    def apply_grid_geometry(self, state):
+        self.applied.append(state)
+
+
+class GridMoveCommandTests(unittest.TestCase):
+    def test_undo_and_redo_restore_complete_grid_state(self):
+        widget = FakeCreateWidget()
+        before = GridGeometry(parent="Widget1", row=2, column=3, sticky="ew")
+        after = GridGeometry(
+            parent="Widget2",
+            row=5,
+            column=6,
+            columnspan=2,
+            rowspan=3,
+            sticky="nsew",
+        )
+        command = undoredo.GridMoveCommand(widget, before, after)
+
+        command.execute()
+        command.undo()
+
+        self.assertEqual(widget.applied, [after, before])
+        self.assertEqual(command.description, "reparent Widget3")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_widget_persistence.py
+++ b/tests/test_widget_persistence.py
@@ -1,0 +1,127 @@
+import unittest
+
+import createWidget as cw
+import project_format
+import pytkguivars as my_vars
+from layout_model import GridGeometry
+
+
+class FakeWidget:
+    widgetName = "ttk::button"
+
+    def __init__(self):
+        self._user_attrs = {
+            "command": "run_report",
+            "textvariable": "button_text",
+        }
+        self.values = {
+            "text": "Run",
+            "command": "140234567890callback",
+            "textvariable": "PY_VAR0",
+            "yscrollcommand": "140234567890set",
+        }
+
+    def place_info(self):
+        return {}
+
+    def grid_info(self):
+        return {}
+
+    def keys(self):
+        return list(self.values)
+
+    def __getitem__(self, key):
+        return self.values[key]
+
+
+class FakeCreateWidget:
+    def __init__(self, widget):
+        self.pythonName = "Widget0"
+        self.widget = widget
+
+    def capture_grid_geometry(self):
+        return GridGeometry(
+            parent="Widget9",
+            row=3,
+            column=4,
+            columnspan=2,
+            sticky="ew",
+        )
+
+
+class WidgetPersistenceTests(unittest.TestCase):
+    def setUp(self):
+        self.old_names = cw.createWidget.widgetNameList
+        self.old_objects = cw.createWidget.widgetObjectList
+        self.old_manager = my_vars.geomManager
+        self.old_root_name = getattr(my_vars, "rootWidgetName", None)
+
+        self.widget = FakeWidget()
+        self.cwo = FakeCreateWidget(self.widget)
+        cw.createWidget.widgetNameList = [
+            ["Widget0", "Widget9", self.widget, []],
+        ]
+        cw.createWidget.widgetObjectList = [self.cwo]
+        my_vars.geomManager = "Grid"
+        my_vars.rootWidgetName = "rootWidget"
+
+    def tearDown(self):
+        cw.createWidget.widgetNameList = self.old_names
+        cw.createWidget.widgetObjectList = self.old_objects
+        my_vars.geomManager = self.old_manager
+        if self.old_root_name is not None:
+            my_vars.rootWidgetName = self.old_root_name
+
+    def test_save_uses_authoritative_grid_and_raw_command_values(self):
+        saved = my_vars.saveWidgetAsDict("Widget0")["Widget0"]
+        attributes = project_format.attribute_map("Widget0", saved)
+
+        self.assertEqual(attributes["command"], "run_report")
+        self.assertEqual(attributes["textvariable"], "button_text")
+        self.assertNotIn("yscrollcommand", attributes)
+        widget_definition = my_vars.buildAWidget(0, saved)
+        self.assertIn("command='run_report'", widget_definition)
+        self.assertIn("textvariable='button_text'", widget_definition)
+        self.assertEqual(
+            saved["GeomData"],
+            {
+                "row": "3",
+                "column": "4",
+                "columnspan": "2",
+                "rowspan": "1",
+                "sticky": "ew",
+                "padx": "2",
+                "pady": "2",
+                "ipadx": "0",
+                "ipady": "0",
+            },
+        )
+
+    def test_rebuilt_widget_can_be_saved_again_without_losing_command(self):
+        first_save = my_vars.saveWidgetAsDict("Widget0")["Widget0"]
+        rebuilt = FakeWidget()
+        rebuilt._user_attrs = {}
+        project_format.remember_preserved_attributes(rebuilt, "Widget0", first_save)
+        rebuilt_cwo = FakeCreateWidget(rebuilt)
+        cw.createWidget.widgetNameList = [["Widget0", "Widget9", rebuilt, []]]
+        cw.createWidget.widgetObjectList = [rebuilt_cwo]
+
+        second_save = my_vars.saveWidgetAsDict("Widget0")["Widget0"]
+        attributes = project_format.attribute_map("Widget0", second_save)
+
+        self.assertEqual(attributes["command"], "run_report")
+        self.assertEqual(attributes["textvariable"], "button_text")
+
+    def test_plain_live_callback_is_migrated_to_explicit_metadata(self):
+        self.widget._user_attrs = {}
+        self.widget.values["command"] = "run_report"
+
+        saved = my_vars.saveWidgetAsDict("Widget0")["Widget0"]
+        attributes = project_format.attribute_map("Widget0", saved)
+
+        self.assertEqual(attributes["command"], "run_report")
+        self.assertEqual(self.widget._user_attrs["command"], "run_report")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/undoredo.py
+++ b/undoredo.py
@@ -22,6 +22,7 @@ Command classes (all importable from this module)
 --------------------------------------------------
     MoveCommand(cw_obj, old_x, old_y, old_w, old_h,
                          new_x, new_y, new_w, new_h)
+    GridMoveCommand(cw_obj, old_grid_state, new_grid_state)
     ResizeCommand          – alias, same signature as MoveCommand
     CreateCommand(cw_obj, widget_snapshot)
     DeleteCommand(parent_widget, widget_snapshot,
@@ -43,6 +44,9 @@ from __future__ import annotations
 import logging
 import tkinter as tk
 from typing import Any
+
+import project_format
+from layout_model import GridGeometry
 
 # import ttkbootstrap as tboot
 
@@ -106,6 +110,7 @@ def restore_widget(snapshot: dict, mainFrame) -> Any | None:
         return None
 
     w = cw.createWidget(mainFrame, widget)
+    project_format.remember_preserved_attributes(widget, widgetName, wDict)
 
     mgr = myVars.geomManager
     if mgr == "Place":
@@ -113,14 +118,11 @@ def restore_widget(snapshot: dict, mainFrame) -> Any | None:
         if place:
             w.addPlace(place)
     elif mgr == "Grid":
-        gd = wDict.get("GeomData") or {}
-        widget.grid(
-            row=int(gd.get("row", 0)),
-            column=int(gd.get("column", 0)),
-            sticky=gd.get("sticky", "WE"),
-            padx=int(gd.get("padx", 2)),
-            pady=int(gd.get("pady", 2)),
+        state = GridGeometry.from_mapping(
+            wDict.get("GeomData"),
+            parent=wDict.get("WidgetParent", myVars.rootWidgetName),
         )
+        w.apply_grid_geometry(state)
     elif mgr == "Pack":
         gd = wDict.get("GeomData") or {}
         widget.pack(
@@ -191,7 +193,7 @@ class MoveCommand(Command):
         if mgr == "Place":
             obj.widget.place(x=x, y=y, width=w, height=h)
         elif mgr == "Grid":
-            obj.widget.grid(row=obj.row, column=obj.col, padx=2, pady=2, sticky="WE")
+            obj.apply_grid_geometry(obj.capture_grid_geometry())
         elif mgr == "Pack":
             obj.widget.pack(padx=4, pady=4, anchor="nw")
 
@@ -203,6 +205,33 @@ class MoveCommand(Command):
 
 
 ResizeCommand = MoveCommand  # same data, semantic alias
+
+
+# ---------------------------------------------------------------------------
+# Grid move / resize / re-parent
+# ---------------------------------------------------------------------------
+
+
+class GridMoveCommand(Command):
+    """Restore complete before/after Grid geometry, including logical parent."""
+
+    def __init__(
+        self,
+        cw_obj,
+        old_state: GridGeometry,
+        new_state: GridGeometry,
+    ):
+        self.cw_obj = cw_obj
+        self.old_state = old_state
+        self.new_state = new_state
+        action = "reparent" if old_state.parent != new_state.parent else "move"
+        self.description = f"{action} {cw_obj.pythonName}"
+
+    def execute(self):
+        self.cw_obj.apply_grid_geometry(self.new_state)
+
+    def undo(self):
+        self.cw_obj.apply_grid_geometry(self.old_state)
 
 
 # ---------------------------------------------------------------------------
@@ -309,9 +338,8 @@ class EditAttributeCommand(Command):
         self.description = f"edit {key} on {getattr(widget, 'widgetName', str(widget))}"
 
     def _apply(self, val: str):
-        if not val:
-            return
         try:
+            project_format.remember_widget_value(self.widget, self.key, val)
             self.widget.configure(**{self.key: val})
         except tk.TclError as e:
             log.warning(


### PR DESCRIPTION
## What changed

- centralize complete Grid geometry in one serializable state model
- fix nested-container drag coordinates, span resizing, automatic reparenting, and Grid undo/redo
- prevent a click without movement from unexpectedly reparenting a widget
- preserve `command`, `postcommand`, `textvariable`, and `variable` design names across save, load, duplicate, undo restoration, and Python generation
- validate and atomically replace JSON project files while retaining five rolling backups
- rebuild project hierarchy from canonical parent data and restore geometry consistently
- configure required root and nested Grid rows/columns in generated Python
- retain Pack only for legacy-project compatibility and document it as deferred
- add focused tests for Grid state, generated extents, callback persistence, JSON rotation, and Grid undo

## Why

Grid state was split between live Tk geometry, createWidget fields, JSON, editor state, and undo commands. During dragging, widgets temporarily use `place()`, which made `grid_info()` stale and caused incorrect coordinates or lost parent/span information.

Callback attributes are design-time Python names, but Tk can expose internal Tcl command identifiers after configuration. Reconstructing projects from those live values could therefore lose or corrupt the original function names.

## Validation

- `python -m unittest discover -v` — 13 tests pass
- `python -m py_compile *.py tests/*.py`
- focused Ruff fatal-error checks
- Ruff checks for the new pure modules and tests
- Black and isort checks
- `git diff --check`

A live Tk window smoke test still needs to be run on a system with a display server.