### PR TITLE
Stabilize Grid, Place, and project persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,11 +207,11 @@ myWidget.place(x=80, y=40, width=120, height=28, anchor='nw', bordermode='inside
 ```
 
 ### Grid (default)
-Widgets snap to a row/column grid. Dragging across container boundaries recalculates the cell in the target container, and edge drags adjust row/column spans. The toolbar controls how many rows and columns are drawn. Its **Grid colour** menu uses the standard colour chooser, can return guides to the active theme colour, and opens **Grid settings** for row/column `minsize` and `pad` values.
+Widgets snap to a row/column grid. Dragging across container boundaries recalculates the cell in the target container, and edge drags adjust row/column spans. The toolbar controls how many rows and columns are drawn. Its **Grid settings** menu uses the standard colour chooser, can return guides to the active theme colour, and opens the settings editor for row/column `minsize` and `pad` values.
 
-New widgets start with useful type-specific spans—for example, input fields are wider while text areas and containers cover several rows and columns. In a widget's **Layout** popup, **Save type default** stores the current `columnspan`, `rowspan`, padding and `sticky` values for future widgets of that type. **Save as tool default** in Grid settings stores the project-level Grid settings. Both are kept in `~/.config/pytkgui/tool_defaults.json` on Linux (or the platform-equivalent configuration directory).
+New widgets start with useful type-specific spans—for example, input fields are wider while text areas and containers cover several rows and columns. In a widget's **Layout** popup, **Save default** stores the current `columnspan`, `rowspan`, padding and `sticky` values for future widgets of that type. **Save as tool default** in Grid settings stores the current Grid settings as defaults for new projects. Existing projects retain the values saved in their project JSON. Tool defaults are kept in `~/.config/pytkgui/tool_defaults.json` on Linux (or the platform-equivalent configuration directory). Saving a widget-type default preserves any Grid sizes and padding edited directly in that file.
 
-**Tools ▸ Compact Grid** closes unused gaps and reduces the configured grid to its occupied extent. Generated code configures the required rows and columns before using `grid(row=…, column=…, sticky=…, padx=…, pady=…)`. Best for responsive forms and tables.
+Container widgets save their actual internal row and column counts, including extra tracks created while editing, so reopened projects and generated programs use the same layout. **Tools ▸ Compact Grid** closes unused gaps and reduces the configured root grid to its occupied extent. Generated code configures the required rows and columns before using `grid(row=…, column=…, sticky=…, padx=…, pady=…)`. Best for responsive forms and tables.
 
 ```python
 myWidget.grid(row=1, column=2, sticky='WE', padx=2, pady=2)
@@ -314,7 +314,7 @@ Re-generating **does not overwrite code you have already written**.  The tool us
 1. Build the layout in PyTkQuickGui.
 2. *File ▸ Generate Python* → choose (or accept) a `.py` path.
 3. Open that file in your IDE and write your logic (remove the `# AUTO-GENERATED STUB` lines as you go).
-4. Return to PyTkQuickGui, adjust the layout, re-run *Generate Python* — PyTkQuickGui auto-fills the dialog with the last used path and merges your code back in.
+4. Return to PyTkQuickGui, adjust the layout, re-run *Generate Python* — PyTkQuickGui reuses the last directory, proposes `<project-name>.py`, and merges your code back in.
 
 > **Note:** *File ▸ Trial Run* generates a **temporary** internal file and runs it.  It does **not** update your saved `.py` file and does not trigger code preservation — it is intended only for a quick layout preview.
 

--- a/README.md
+++ b/README.md
@@ -207,7 +207,11 @@ myWidget.place(x=80, y=40, width=120, height=28, anchor='nw', bordermode='inside
 ```
 
 ### Grid (default)
-Widgets snap to a row/column grid. Dragging across container boundaries recalculates the cell in the target container, and edge drags adjust row/column spans. The toolbar controls how many rows and columns are drawn and lets you choose a guide colour or use the active theme colour. **Tools ▸ Compact Grid** closes unused gaps and reduces the configured grid to its occupied extent. Generated code configures the required rows and columns before using `grid(row=…, column=…, sticky=…, padx=…, pady=…)`. Best for responsive forms and tables.
+Widgets snap to a row/column grid. Dragging across container boundaries recalculates the cell in the target container, and edge drags adjust row/column spans. The toolbar controls how many rows and columns are drawn. Its **Grid colour** menu uses the standard colour chooser, can return guides to the active theme colour, and opens **Grid settings** for row/column `minsize` and `pad` values.
+
+New widgets start with useful type-specific spans—for example, input fields are wider while text areas and containers cover several rows and columns. In a widget's **Layout** popup, **Save type default** stores the current `columnspan`, `rowspan`, padding and `sticky` values for future widgets of that type. **Save as tool default** in Grid settings stores the project-level Grid settings. Both are kept in `~/.config/pytkgui/tool_defaults.json` on Linux (or the platform-equivalent configuration directory).
+
+**Tools ▸ Compact Grid** closes unused gaps and reduces the configured grid to its occupied extent. Generated code configures the required rows and columns before using `grid(row=…, column=…, sticky=…, padx=…, pady=…)`. Best for responsive forms and tables.
 
 ```python
 myWidget.grid(row=1, column=2, sticky='WE', padx=2, pady=2)

--- a/README.md
+++ b/README.md
@@ -1,414 +1,396 @@
 # PyTkQuickGui
 
-Notice: The current version relies on ttkbootstrap version 2.0. Still getting the gremlins out. I will uppdate a stable usable version by the end of July 2026. 
+PyTkQuickGui is a visual drag-and-drop builder for Python desktop interfaces
+using tkinter and ttkbootstrap. Design a window on the live canvas, edit widget
+attributes and layout, save the project as JSON, then generate a readable Python
+program.
 
-Note: This is in active development. It is "alpha" code with quite a few knows glitches and errors. At this stage it is usefull enough to try out and do simple tasks. At present some widgest are not included as there are issues to resolve. Only two grid methods are available, the "Place" gridder being the most stable, "Grid" works reasonably well but re-parenting is an issue.  "Pack" is greayed out for now, this will be tackeked later.
-
-**A visual drag-and-drop GUI builder for Python / ttkbootstrap applications.**
-
-PyTkQuickGui lets you lay out tkinter widgets by dragging, resizing, and editing them on a live canvas, then generates a complete, ready-to-run Python file with all the boilerplate already written.  You fill in the business logic; PyTkQuickGui handles the widget creation and placement code.
-
-> **Status:** Alpha – functional and actively used, but still growing.  Some widget types have not been fully integrated. Feedback and contributions are very welcome.
-
----
+The project is approaching beta. Grid and Place projects are usable and under
+active testing; Pack remains disabled while the other two geometry managers are
+stabilised.
 
 ## Screenshots
 
-| Place mode — multi-container layout | Place mode — instrument test tool |
+| Place layout | Instrument-style project |
 |---|---|
-| ![PyTkQuickGui Place mode – platypus project](docs/screenshot_place_platypus.png) | ![PyTkQuickGui Place mode – test tool project](docs/screenshot_place_test_tool.png) |
+| ![PyTkQuickGui Place project](docs/screenshot_place_platypus.png) | ![PyTkQuickGui instrument project](docs/screenshot_place_test_tool.png) |
 
----
+## What it does
 
-## Table of Contents
-
-1. [Features](#features)
-2. [Requirements](#requirements)
-3. [Installation](#installation)
-4. [Quick Start](#quick-start)
-5. [Interface Overview](#interface-overview)
-6. [Working with Widgets](#working-with-widgets)
-7. [Geometry Managers](#geometry-managers)
-8. [Project Files (JSON)](#project-files-json)
-9. [Generating Python Code](#generating-python-code)
-10. [Keyboard & Mouse Reference](#keyboard--mouse-reference)
-11. [Widget Reference](#widget-reference)
-12. [Themes](#themes)
-13. [Known Limitations](#known-limitations)
-14. [Contributing](#contributing)
-15. [License](#license)
-
----
-
-## Features
-
-| Feature | Details |
-|---|---|
-| **Visual layout** | Drag, resize and re-parent widgets on a live canvas |
-| **Geometry managers** | Choose **Place** or **Grid** when creating a project; **Pack** is intentionally disabled for now |
-| **ttkbootstrap widgets** | Label, Button, Entry, Combobox, Spinbox, Checkbutton, Radiobutton, Scale, Progressbar, Floodgauge, Meter, Notebook, Canvas, Frame, Labelframe, Panedwindow |
-| **Standard tk/ttk widgets** | Text, Listbox, Treeview, Scrollbar, Separator, Sizegrip |
-| **Widget editor** | Edit every configurable attribute through generated combo/spinbox/entry controls |
-| **Colour & font pickers** | Integrated colour chooser and font dialog |
-| **Image support** | Attach PNG/JPG images to Label or Button widgets |
-| **Themes** | All ttkbootstrap themes available from the Theme menu |
-| **Code generation** | Produces a single, clean Python file – import + window setup + all widgets + blank callbacks + tk variables |
-| **JSON project files** | Human-readable save format; easily version-controlled or hand-edited |
-| **Legacy format** | Old `.pk1` (pickle) project files are detected and loaded automatically; re-saved as JSON |
-| **Rolling backups** | Up to 5 automatic backup copies (`.json-save1` … `.json-save5`) |
-
----
+- Builds ttkbootstrap interfaces visually on a live design surface.
+- Uses responsive Grid layout by default, or free-form Place layout.
+- Moves, resizes, duplicates, deep-clones, deletes, groups, and re-parents
+  widgets.
+- Edits widget attributes with colour, font, image, entry, combo, and spinbox
+  controls.
+- Gives Grid and Place widgets useful type-specific layout defaults.
+- Keeps child layouts inside Frame, Labelframe, and Panedwindow containers.
+- Saves human-readable JSON projects with atomic writes and rolling backups.
+- Preserves design-time callback and Tk-variable names through save, reload,
+  duplication, and code generation.
+- Generates clean multiline Python calls and preserves callback bodies edited
+  in a previously generated file.
+- Supports undo and redo for the main editing operations.
+- Applies ttkbootstrap themes to the builder and generated program.
 
 ## Requirements
 
-```
-Python >= 3.10
-ttkbootstrap >= 1.10
-tkfontchooser
-coloredlogs
-Pillow
-```
+- Python 3.10 or newer
+- tkinter (sometimes supplied as a separate operating-system package)
+- ttkbootstrap 2.0 or newer
+- tkfontchooser
+- coloredlogs
+- Pillow
 
-See `requirments.txt` for the full list.
+The complete Python dependency list is in
+[`requirments.txt`](requirments.txt). The filename is retained for compatibility
+with existing setup instructions.
 
----
-
-## Installation
-
-```bash
-# 1. Clone the repository
-git clone https://github.com/ChrisMcGowanAu/PyTkQuickGui.git
-cd PyTkQuickGui
-
-# 2. Create and activate a virtual environment (recommended)
-python -m venv .venv
-source .venv/bin/activate      # Windows: .venv\Scripts\activate
-
-# 3. Install dependencies
-pip install -r requirments.txt
-
-# 4. Run
-python pytkquickgui.py
-```
-
-On Linux you may need `python3-tk` installed at the system level:
+On Debian or Ubuntu, install tkinter if it is not already present:
 
 ```bash
 sudo apt install python3-tk
 ```
 
----
+## Installation
 
-## Quick Start
+```bash
+git clone https://github.com/ChrisMcGowanAu/PyTkQuickGui.git
+cd PyTkQuickGui
 
-1. **Launch** `python pytkquickgui.py`
-2. **New project** → *File ▸ New Project* – enter a name and click OK.
-3. **Add a widget** → right-click anywhere on the canvas; pick a widget from the pop-up menu.  It appears under your cursor.
-4. **Move** → left-click and drag.
-5. **Resize** → left-click near an edge and drag.
-6. **Edit** → right-click a widget → *Edit* to change text, colour, font, style, etc.
-7. **Save** → *File ▸ Save Project* (saves a `.json` file).
-8. **Generate** → *File ▸ Generate Python* – choose where to save the `.py` file and open it in your IDE.
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirments.txt
 
----
-
-## Interface Overview
-
-```
-┌──────────────────────────────────────────────────────────────┐
-│  Menu bar: File | Theme | Tools | Help                        │
-├──────────────────────────────────────────────────────────────┤
-│  Toolbar: [Geometry Manager] Place | Grid | Pack   Layout: X │
-├──────────────────────────────────────────────────────────────┤
-│                                                              │
-│   Canvas  (drag & drop widgets here)                         │
-│                                                              │
-│                                                        ▣     │  ← size-grip
-└──────────────────────────────────────────────────────────────┘
+python pytkquickgui.py
 ```
 
-### Menu Items
+On Windows, activate the environment with:
 
-| Menu | Item | Action |
-|---|---|---|
-| File | New Project | Create a new project folder |
-| File | Open last Project | Reload the most recently saved project |
-| File | Open Project | Browse to a project directory |
-| File | Save Project | Save to JSON |
-| File | Trial Run | Generate code and run it in a subprocess |
-| File | Generate Python | Generate code and save to a location you choose |
-| File | Exit | Save-prompt then quit |
-| Theme | (theme names) | Switch ttkbootstrap theme live |
-| Tools | Hide/Show Label Borders | Toggle 1-pixel border on all Labels |
-| Tools | Set default label font | Change font on all Label widgets |
-| Tools | Set default style font | Change font for all ttk widget types |
-| Tools | Open backup file | Load one of the rolling `.json-saveN` backups |
-| Tools | Widget Tree | Print widget hierarchy to the terminal |
-| Help | Welcome | About box |
-| Help | Help | In-app tabbed help window |
+```powershell
+.venv\Scripts\activate
+```
 
----
+## Quick start
 
-## Working with Widgets
+1. Run `python pytkquickgui.py`.
+2. Select **File → New Project**, enter a project name, and choose Grid or
+   Place.
+3. Right-click the design surface and choose a widget.
+4. Drag the widget to move it. In Place mode, drag an edge to resize it.
+   In Grid mode, movement changes its row and column and edge drags adjust its
+   span.
+5. Right-click the widget and use **Edit** for attributes or **Layout** for
+   geometry.
+6. Use **File → Save Project** to save the JSON project.
+7. Use **File → Trial Run** to preview it or **File → Generate Python** to
+   write a program.
 
-### Adding a Widget
-Right-click on the **canvas** to open the widget palette.  Container widgets (Frame, Labelframe, Panedwindow) appear at the top, followed by all other widget types.  Click a name and the widget is placed at the cursor position.
+## Interface
 
-### Selecting and Moving
-Left-click and hold anywhere in the middle of a widget, then drag to reposition.
+The top toolbar shows the active layout manager. Grid projects also expose:
 
-### Resizing
-Left-click and hold **near an edge** (within ~8 pixels) of a widget, then drag.  Each edge acts independently:
+- **Rows** and **Cols** controls for the root design grid.
+- **Grid settings** for guide colour, row and column minimum sizes, padding,
+  and saving the current settings as tool defaults.
+- An undo status at the right.
 
-| Drag zone | Effect |
+The geometry manager is selected for the project. Once widgets exist, switching
+manager is blocked because mixing managers in one Tk parent leads to invalid
+layouts. Start a new project to use a different manager.
+
+### Main menus
+
+| Menu | Important actions |
 |---|---|
-| Right edge | Expand / shrink width |
-| Left edge | Move left edge (changes x and width) |
-| Bottom edge | Expand / shrink height |
-| Top edge | Move top edge (changes y and height) |
+| File | New, open, close, save, save as, Trial Run, Generate Python |
+| Edit | Undo, redo, group selected widgets, ungroup |
+| Theme | Light, dark, and legacy ttkbootstrap themes |
+| Tools | Label borders, default fonts/styles, backups, widget tree, Compact Grid |
+| Help | Welcome and the in-application guide |
 
-After release, the position and size are snapped to a 16-pixel grid.
+## Working with widgets
 
-### Right-Click Context Menu (on a widget)
+Right-click empty space to open the widget palette. The current palette contains
+these container widgets:
 
-| Item | Effect |
+- Frame
+- Labelframe
+- Panedwindow
+
+These regular widgets are currently enabled:
+
+- Label
+- Button
+- Entry
+- Combobox
+- Spinbox
+- Checkbutton
+- Radiobutton
+- Scale
+- Progressbar
+- Canvas
+- Text
+- Listbox
+- Separator
+
+Other Tk and ttkbootstrap widget implementations remain in the source while
+their designer behaviour is completed, but they are not offered in the palette.
+
+### Widget context menu
+
+| Action | Result |
 |---|---|
-| Edit | Opens the attribute editor popup |
-| Layout | Opens the x / y / width / height editor (Place manager only) |
-| Clone | Creates a copy at the same position |
-| DeepClone | Copies a container widget *and* all its children |
-| Re-Parent | Drops the widget into whichever container currently encloses it |
+| Edit | Opens the scrollable attribute editor |
+| Layout | Opens geometry values for the current manager |
+| Duplicate | Copies one widget |
+| Clone | Deep-copies a container and its children |
+| Re-Parent | Places the widget in the enclosing container, or back at the root |
 | Delete | Removes the widget |
+| Add to Selection | Adds the widget to the current multi-selection |
+| Group Selected | Creates a logical group from selected widgets |
 
-### Attribute Editor
-The **Edit** popup shows every configurable key for the selected widget.  Controls are chosen based on the key type:
+The Edit and Layout popups put the action buttons at both the top and bottom.
+The duplicate controls are intentional: short forms remain convenient while
+long forms do not force the user to scroll to a particular end. Popups can be
+moved with the yellow drag handle.
 
-* **Combobox** – anchor, relief, justify, orient, cursor, style/bootstyle
-* **Spinbox** – height, width, borderwidth, padding
-* **Button** – font picker, colour picker, image selector
-* **Entry** – everything else (text, command, variable names, etc.)
+The attribute editor stores callback fields such as `command` and variable
+fields such as `textvariable` as Python names, rather than trusting Tk's
+internal Tcl command strings. Use valid top-level Python identifiers for these
+values, for example `save_record` or `customer_name`.
 
-Click **Apply** to commit changes; **Close** to discard.
+## Geometry managers
 
-### Re-parenting
-When you release a widget on top of a container (Frame, Labelframe, etc.), the tool automatically detects the overlap and re-parents the widget.  You can also trigger this manually via the right-click *Re-Parent* command.
+### Grid
 
----
+Grid is the default and is recommended for responsive forms. Widgets use
+`row`, `column`, `columnspan`, `rowspan`, `padx`, `pady`, `ipadx`, `ipady`, and
+`sticky`.
 
-## Geometry Managers
+New widgets receive type-specific defaults. For example, entries span more
+columns than labels, while text areas and containers span several rows and
+columns. Open a widget's **Layout** popup and select **Save default** to make
+its current Grid layout the default for future widgets of that type.
 
-PyTkQuickGui currently supports **Place** and **Grid**. Choose the manager when creating a project; the setting is saved with the project.
+Rows and columns expand with the design surface. Container widgets keep their
+own internal grid dimensions, including extra tracks created while editing.
+Those dimensions are stored in the project and reproduced in Trial Run and
+generated Python.
+
+Use **Tools → Compact Grid** to remove unoccupied gaps and reduce the configured
+root grid to its occupied extent.
+
+Example generated geometry:
+
+```python
+Widget0.grid(
+    row=2,
+    column=1,
+    columnspan=3,
+    rowspan=1,
+    sticky="nsew",
+    padx=2,
+    pady=2,
+)
+```
 
 ### Place
-Widgets are positioned with absolute `x`, `y`, `width`, `height` coordinates.  Best for pixel-perfect layouts and quick prototyping.
+
+Place is useful for free-form prototypes and fixed-position controls. It stores
+`x`, `y`, `width`, and `height`.
+
+The drop position always follows the pointer. Initial `width` and `height` are
+type-specific: containers and text areas start larger than buttons and labels.
+Resize a widget, open **Layout**, and select **Save default** to use that size
+for future widgets of the same type.
+
+Example generated geometry:
 
 ```python
-myWidget.place(x=80, y=40, width=120, height=28, anchor='nw', bordermode='inside')
-```
-
-### Grid (default)
-Widgets snap to a row/column grid. Dragging across container boundaries recalculates the cell in the target container, and edge drags adjust row/column spans. The toolbar controls how many rows and columns are drawn. Its **Grid settings** menu uses the standard colour chooser, can return guides to the active theme colour, and opens the settings editor for row/column `minsize` and `pad` values.
-
-New widgets start with useful type-specific spans—for example, input fields are wider while text areas and containers cover several rows and columns. In a widget's **Layout** popup, **Save default** stores the current `columnspan`, `rowspan`, padding and `sticky` values for future widgets of that type. **Save as tool default** in Grid settings stores the current Grid settings as defaults for new projects. Existing projects retain the values saved in their project JSON. Tool defaults are kept in `~/.config/pytkgui/tool_defaults.json` on Linux (or the platform-equivalent configuration directory). Saving a widget-type default preserves any Grid sizes and padding edited directly in that file.
-
-Container widgets save their actual internal row and column counts, including extra tracks created while editing, so reopened projects and generated programs use the same layout. **Tools ▸ Compact Grid** closes unused gaps and reduces the configured root grid to its occupied extent. Generated code configures the required rows and columns before using `grid(row=…, column=…, sticky=…, padx=…, pady=…)`. Best for responsive forms and tables.
-
-```python
-myWidget.grid(row=1, column=2, sticky='WE', padx=2, pady=2)
+Widget0.place(
+    x=80,
+    y=48,
+    width=180,
+    height=32,
+    anchor="nw",
+    bordermode="inside",
+)
 ```
 
 ### Pack
-Pack remains experimental and cannot be selected for a new project. Its existing code is retained for compatibility with old project files, but work on Pack is deferred until Place and Grid are stable.
 
----
+Pack is disabled for new projects. Compatibility code remains for older project
+files, but its visual editing model is deferred until Grid and Place are stable.
 
-## Project Files (JSON)
+## Tool defaults
 
-Projects are stored as plain **JSON** files in `~/.config/pytkgui/<ProjectName>/`.  The file format is intentional – you can open a `.json` project in any text editor and tweak values directly.
+`tool_defaults.py` contains the built-in Grid and Place defaults. Optional
+`tool_defaults.json` files are layered in this order, from lowest to highest
+precedence:
 
-```
-~/.config/pytkgui/
-└── MyProject/
-    ├── MyProject.json          ← current save
-    ├── MyProject-save1.json    ← previous save
-    ├── MyProject-save2.json
-    └── ...
-```
+1. `/etc/pytkgui/tool_defaults.json`
+2. `tool_defaults.json` beside the PyTkQuickGui source modules
+3. `tool_defaults.json` in the directory from which the tool was launched
+4. The user's configuration file
 
-### File structure (excerpt)
+The user file is normally:
+
+- Linux: `~/.config/pytkgui/tool_defaults.json`
+- Linux with `XDG_CONFIG_HOME`: `$XDG_CONFIG_HOME/pytkgui/tool_defaults.json`
+- Windows: `%APPDATA%\pytkgui\tool_defaults.json`
+
+Missing files are ignored. Files may contain only the values they need to
+override; nested widget defaults are merged field by field. The user file has
+highest priority so **Save as tool default** and **Save default** take effect
+without modifying a system or source installation.
+
+The top-level Grid settings are:
+
 ```json
 {
-  "formatVersion": 2,
-  "ProjectName": "MyProject",
-  "theme": "cyborg",
-  "geomManager": "Place",
-  "widgetCount": 3,
-  "widgetNameList": [...],
-  "Widget0": {
-    "WidgetName": "ttk::button",
-    "WidgetParent": "rootWidget",
-    "Place": {"x": "80", "y": "48", "width": "120", "height": "32", ...},
-    "Widget0-KeyCount": 4,
-    "Attribute0": {"Key": "text",  "Value": "Click Me"},
-    "Attribute1": {"Key": "style", "Value": "primary"},
-    ...
-  }
+  "gridRows": 25,
+  "gridCols": 25,
+  "gridLineColor": "",
+  "gridRowMinsize": "2.5m",
+  "gridColMinsize": "5m",
+  "gridRowPad": "2.5m",
+  "gridColPad": "5m"
 }
 ```
 
-### Legacy pickle files (`.pk1`)
-Projects saved by older versions of PyTkQuickGui used Python's `pickle` format (`.pk1` extension).  The loader **automatically detects** whether a file is JSON or pickle — no manual conversion needed:
+Per-widget records live under `gridWidgetDefaults` and
+`placeWidgetDefaults`. Place records contain only `width` and `height`.
 
-1. When you open a project directory PyTkQuickGui looks for `<name>.json` first, then `<name>.pk1`.
-2. When you use *File ▸ Open backup file* both `.json` and `.pk1` entries appear in the file dialog.
-3. A one-time info dialog tells you the file was loaded from the legacy format and will be re-saved as JSON on next save.
+Grid rows, columns, guide colour, minimum sizes, and padding are also saved in
+each project. Project values override tool defaults when that project is
+opened; tool defaults remain the starting values for new projects.
 
-> **Warning:** Hand-editing JSON is powerful but risky.  An invalid JSON file will prevent the project from loading.  Keep a backup copy before editing.
+## Project files
 
-Project writes are validated and atomically replace the current JSON file. Callback and Tk-variable names (`command`, `postcommand`, `textvariable`, and `variable`) are stored as design-time strings so they survive save, reload, duplicate, and subsequent saves without being replaced by Tk's internal Tcl identifiers.
+New projects are stored below the platform configuration directory, normally:
 
----
-
-## Generating Python Code
-
-*File ▸ Generate Python* produces a single `.py` file structured in clearly-marked sections:
-
-```python
-import tkinter as tk
-import ttkbootstrap as tboot
-
-themeName = 'cyborg'
-title     = 'MyProject'
-rootWin   = tboot.Window(themename=themeName, title=title)
-rootWidget = tboot.Frame(rootWin, ...)
-
-####### TK variables #######
-myStringVar = tk.StringVar(rootWin, '0.0')
-
-####### Functions #######
-def onClickMe():
-    # AUTO-GENERATED STUB
-    print('onClickMe')
-
-####### Widgets #######
-Widget0 = tboot.Button(rootWidget, text='Click Me', command=onClickMe, ...)
-Widget0.place(x=80, y=48, width=120, height=32, ...)
-
-####### Main  #######
-rootWin.geometry('800x600')
-rootWin.mainloop()
+```text
+~/.config/pytkgui/MyProject/
 ```
 
-### Preserving your code across re-generations
+The active file is `MyProject.json`. Each save is written to a temporary file,
+parsed for validation, and atomically replaces the active file. Up to five
+earlier versions are rotated as:
 
-Re-generating **does not overwrite code you have already written**.  The tool uses the section markers and a stub-sentinel comment to decide what to keep:
+```text
+MyProject-save1.json
+MyProject-save2.json
+...
+MyProject-save5.json
+```
 
-| Section | Behaviour on re-generate |
-|---|---|
-| `####### TK variables #######` | Variables still at the default `StringVar(rootWin,'0.0')` are replaced; ones you've changed are **preserved** |
-| `####### Functions #######` | Stubs containing `# AUTO-GENERATED STUB` are replaced with a fresh stub; functions you've edited (sentinel removed / real code added) are **preserved verbatim** |
-| `####### Widgets #######` | Always regenerated from the current builder state |
-| `####### Main  #######` | Always regenerated |
+**Tools → Open backup file** can load a saved backup.
 
-**Recommended workflow:**
-1. Build the layout in PyTkQuickGui.
-2. *File ▸ Generate Python* → choose (or accept) a `.py` path.
-3. Open that file in your IDE and write your logic (remove the `# AUTO-GENERATED STUB` lines as you go).
-4. Return to PyTkQuickGui, adjust the layout, re-run *Generate Python* — PyTkQuickGui reuses the last directory, proposes `<project-name>.py`, and merges your code back in.
+Project JSON includes:
 
-> **Note:** *File ▸ Trial Run* generates a **temporary** internal file and runs it.  It does **not** update your saved `.py` file and does not trigger code preservation — it is intended only for a quick layout preview.
+- project name, theme, and geometry manager
+- window and Grid settings
+- widget identity and creation order
+- parent/child relationships
+- Place or Grid geometry
+- container Grid dimensions
+- editable widget attributes
+- callback and Tk-variable design names
+- image references and logical groups
+- the last generated Python path, when available
 
----
+Older `.pk1` pickle projects can still be detected and opened. Because pickle
+can execute code while loading, open legacy files only when you trust their
+source. The next save writes the project in JSON format.
 
-## Keyboard & Mouse Reference
+## Generating Python
 
-| Action | Gesture |
-|---|---|
-| Add widget | Right-click canvas → select widget name |
-| Move widget | Left-drag widget (centre area) |
-| Resize widget | Left-drag near widget edge |
-| Widget context menu | Right-click widget |
-| Snap-to-grid size | 16 px (fixed) |
+**File → Generate Python** proposes `<project-name>.py` in the last output
+directory. Widget constructors and geometry calls are formatted one argument
+per line:
 
----
+```python
+Widget1 = ttk.Frame(
+    rootWidget,
+    width="0",
+    height="0",
+    cursor="arrow",
+    style="primary.TFrame",
+)
+```
 
-## Widget Reference
+The generated file contains marked sections for Tk variables, callback
+functions, widgets, and the main program. Callback names referenced by widgets
+receive an initial stub:
 
-### ttkbootstrap Widgets
+```python
+def save_record():
+    # AUTO-GENERATED STUB
+    print("save_record")
+```
 
-| Widget | Notes |
-|---|---|
-| **Frame** | Container; can hold other widgets |
-| **Labelframe** | Frame with a title label |
-| **Panedwindow** | Splitter container |
-| **Label** | Static text or image |
-| **Button** | Clickable button; supports `command`, `image`, `style` |
-| **Entry** | Single-line text input; supports `textvariable` |
-| **Combobox** | Drop-down selection; set `values` in the editor |
-| **Spinbox** | Numeric or list spinner |
-| **Checkbutton** | Tick-box; supports `variable` |
-| **Radiobutton** | Radio selector; supports `variable`, `value` |
-| **Scale** | Slider; supports `from_`, `to`, `orient` |
-| **Progressbar** | Progress indicator; supports `value`, `orient` |
-| **Floodgauge** | ttkbootstrap animated fill gauge |
-| **Meter** | ttkbootstrap circular gauge; supports `metertype` (`full`/`semi`) |
-| **Notebook** | Tabbed container; use the editor to set tab count |
-| **Canvas** | Drawing surface; scrollbars can be added via the editor |
+When the same generated file is selected again, PyTkQuickGui preserves edited
+callback bodies and customised Tk-variable initialisers. Widget construction
+and geometry sections are rebuilt from the current project. User functions no
+longer referenced by a widget are also retained.
 
-### Standard tk / ttk Widgets
-
-| Widget | Notes |
-|---|---|
-| **Text** | Multi-line text area |
-| **Listbox** | Scrollable list; set `selectmode` in the editor |
-| **Treeview** | Table / tree view; add columns via the editor |
-| **Scrollbar** | Attach to Canvas / Text / Listbox via the editor |
-| **Separator** | Horizontal or vertical divider line |
-| **Sizegrip** | Resize handle for the window corner |
-
----
+**Trial Run** writes and launches a temporary generated file. It is intended for
+layout testing and does not replace the explicitly saved Python file.
 
 ## Themes
 
-PyTkQuickGui uses **ttkbootstrap** themes.  The *Theme* menu lists all available themes.  Selecting one applies it live to both the builder and to the project (it is saved and used in generated code).
+The Theme menu groups ttkbootstrap 2.0 light and dark themes and retains legacy
+theme names for older projects. The selected theme is stored in the project and
+used by generated Python.
 
-Popular themes: `cosmo`, `flatly`, `journal`, `litera`, `lumen`, `minty`, `pulse`, `sandstone`, `united`, `yeti` (light) · `cyborg`, `darkly`, `solar`, `superhero`, `vapor` (dark).
+Changing a theme can alter requested widget sizes. Grid layouts normally absorb
+those differences; check a Trial Run when exact Place dimensions matter.
 
----
+## Troubleshooting
 
-## Known Limitations
+- If a project JSON was hand-edited, validate its JSON syntax first.
+- If a generated callback is skipped, check that its name is a valid Python
+  identifier and not a Python keyword.
+- If Grid guides appear stale after resizing, resize the main window once and
+  report the project JSON and steps needed to reproduce it.
+- Use the most recent `-saveN.json` backup if an active project file is damaged.
+- Runtime detail is written through Python logging. Benign Tk lookups on a
+  widget already destroyed during cleanup are logged at debug level.
 
-* **Meter widget** – the ttkbootstrap `Meter` widget has some quirks when used inside containers; if it does not display correctly, try running a Trial Run and see how it looks in the generated app.
-* **Scrollbar attachment** – automatic scrollbar wiring (via the Edit → `vertical_scrollbar` / `horizontal_scrollbar` controls) currently works only with the **Grid** manager.
-* **Notebook tabs** – tab count is set in the Edit popup; individual tab frames need to be re-parented manually.
-* **Pack geometry** – Pack is intentionally disabled for new projects while its interaction model is redesigned.
-* **No undo** – accidental deletions cannot be undone from the GUI; use *File ▸ Open backup file* to recover from a save point.
+## Current limitations
 
----
+- Pack cannot be selected for a new project.
+- The palette deliberately exposes a smaller widget set while remaining widgets
+  are stabilised.
+- Some complex widgets require application-specific setup that a visual builder
+  cannot infer, such as connecting scrollbars to targets.
+- Trial Run and visual editing require a desktop session with Tk support.
+- Legacy pickle compatibility is temporary and should be treated as a migration
+  path to JSON.
 
-## Contributing
+## Development and testing
 
-Pull requests are welcome!  Please:
+Run the unit tests from the repository root:
 
-1. Fork the repository and create a feature branch.
-2. Follow the existing code style (PEP 8, `log.xxx()` for logging).
-3. Test manually with at least the `cyborg` and `flatly` themes.
-4. Open a PR with a clear description of the change.
+```bash
+python -m unittest discover -s tests -v
+```
 
-Areas that need work:
+When contributing:
 
-- [ ] Undo / redo history
-- [ ] Notebook tab management in the editor
-- [ ] More widget attributes exposed in the editor (e.g. Treeview columns)
-- [ ] Pack mode drag re-ordering
-- [ ] Website / video tutorial
+1. Work on a focused branch.
+2. Keep generated and persistence formats backwards-compatible where practical.
+3. Use `logging` instead of diagnostic `print` calls in application code.
+4. Test both Grid and Place, including a child widget inside a container.
+5. Test a save, reload, Trial Run, and generated Python file.
+6. Check at least one light and one dark ttkbootstrap theme.
 
----
+Bug reports are most useful when they include the project JSON, the selected
+geometry manager, the sequence of editing actions, and the complete traceback.
 
 ## License
 
-MIT – see [LICENSE](LICENSE) for details.
+MIT. See [`LICENSE`](LICENSE).
 
----
-
-*PyTkQuickGui – Chris McGowan 2024-2026*
+PyTkQuickGui — Chris McGowan, 2024–2026.

--- a/README.md
+++ b/README.md
@@ -199,15 +199,15 @@ When you release a widget on top of a container (Frame, Labelframe, etc.), the t
 
 PyTkQuickGui currently supports **Place** and **Grid**. Choose the manager when creating a project; the setting is saved with the project.
 
-### Place (default)
+### Place
 Widgets are positioned with absolute `x`, `y`, `width`, `height` coordinates.  Best for pixel-perfect layouts and quick prototyping.
 
 ```python
 myWidget.place(x=80, y=40, width=120, height=28, anchor='nw', bordermode='inside')
 ```
 
-### Grid
-Widgets snap to a row/column grid. Dragging across container boundaries recalculates the cell in the target container, and edge drags adjust row/column spans. Generated code configures the required rows and columns before using `grid(row=…, column=…, sticky=…, padx=…, pady=…)`. Best for responsive forms and tables.
+### Grid (default)
+Widgets snap to a row/column grid. Dragging across container boundaries recalculates the cell in the target container, and edge drags adjust row/column spans. The toolbar controls how many rows and columns are drawn and lets you choose a guide colour or use the active theme colour. **Tools ▸ Compact Grid** closes unused gaps and reduces the configured grid to its occupied extent. Generated code configures the required rows and columns before using `grid(row=…, column=…, sticky=…, padx=…, pady=…)`. Best for responsive forms and tables.
 
 ```python
 myWidget.grid(row=1, column=2, sticky='WE', padx=2, pady=2)

--- a/createWidget.py
+++ b/createWidget.py
@@ -362,13 +362,14 @@ class createWidget:
         # log.debug(random.randint(3,  9))
         self.row = 4
         self.col = 4
-        self.columnspan = 1  # number of grid columns this widget spans
-        self.rowspan = 1  # number of grid rows    this widget spans
-        self.sticky = "nsew"  # tkinter sticky string — user-controlled
-        self.padx = 2  # grid padx  (external padding)
-        self.pady = 2  # grid pady  (external padding)
-        self.ipadx = 0  # grid ipadx (internal padding / extra width)
-        self.ipady = 0  # grid ipady (internal padding / extra height)
+        grid_defaults = myVars.gridDefaultsForWidget(self.widget.widgetName)
+        self.columnspan = grid_defaults["columnspan"]
+        self.rowspan = grid_defaults["rowspan"]
+        self.sticky = grid_defaults["sticky"]
+        self.padx = grid_defaults["padx"]
+        self.pady = grid_defaults["pady"]
+        self.ipadx = grid_defaults["ipadx"]
+        self.ipady = grid_defaults["ipady"]
         # Pack geometry fields — authoritative user-set values
         self.pack_side = "top"  # pack side
         self.pack_fill = "none"  # pack fill

--- a/createWidget.py
+++ b/createWidget.py
@@ -781,7 +781,21 @@ class createWidget:
         if myVars.geomManager != "Place":
             return
 
-        place = self.widget.place_info()
+        try:
+            if not self.widget.winfo_exists():
+                log.debug(
+                    "reParent: %s no longer exists; request ignored",
+                    self.pythonName,
+                )
+                return
+            place = self.widget.place_info()
+        except tk.TclError as exc:
+            log.debug(
+                "reParent: %s is no longer available (%s); request ignored",
+                self.pythonName,
+                exc,
+            )
+            return
         x_str = place.get("x")
         y_str = place.get("y")
         w_str = place.get("width")
@@ -803,7 +817,18 @@ class createWidget:
         for sib in createWidget.widgetList:
             if sib is None or sib is self.widget:
                 continue
-            sib_place = sib.place_info()
+            try:
+                if not sib.winfo_exists():
+                    log.debug("reParent: skipping destroyed sibling %s", sib)
+                    continue
+                sib_place = sib.place_info()
+            except tk.TclError as exc:
+                log.debug(
+                    "reParent: skipping unavailable sibling %s (%s)",
+                    sib,
+                    exc,
+                )
+                continue
             wx_str = sib_place.get("x")
             wy_str = sib_place.get("y")
             if wx_str is None or wy_str is None:

--- a/createWidget.py
+++ b/createWidget.py
@@ -324,7 +324,22 @@ class createWidget:
     lastCreated = None
     dragType = ["move", "dragEast", "dragWest", "dragNorth", "dragSouth"]
 
-    def __init__(self, root, widget):
+    @classmethod
+    def _allocate_identity(cls, python_name: str | None = None) -> tuple[int, str]:
+        """Allocate a new ID or reserve an exact persisted ``WidgetN`` name."""
+        if python_name is None:
+            widget_id = cls.widgetId
+            cls.widgetId += 1
+            return widget_id, "Widget" + str(widget_id)
+        if not python_name.startswith("Widget") or not python_name[6:].isdigit():
+            raise ValueError(f"invalid saved widget name: {python_name!r}")
+        if any(nl[NAME] == python_name for nl in cls.widgetNameList):
+            raise ValueError(f"duplicate saved widget name: {python_name}")
+        widget_id = int(python_name[6:])
+        cls.widgetId = max(cls.widgetId, widget_id + 1)
+        return widget_id, python_name
+
+    def __init__(self, root, widget, python_name: str | None = None):
         self.bordermode = None
         self.parentX = 0
         self.parentY = 0
@@ -379,17 +394,15 @@ class createWidget:
         )
 
         log.debug(self.widget.widgetName)
-        self.pythonName = "Widget" + str(createWidget.widgetId)
+        self.widgetId, self.pythonName = createWidget._allocate_identity(python_name)
         # Stamp pythonName onto the tk widget itself so editWidget.py can
         # look up the createWidget object via findCreateWidgetObject().
         self.widget.pythonName = self.pythonName
-        log.debug("Widget ID %s", str(createWidget.widgetId))
+        log.debug("Widget ID %s", str(self.widgetId))
         createWidget.widgetList.append(self.widget)
         createWidget.widgetNameList.append(
             [self.pythonName, myVars.rootWidgetName, self.widget, []]
         )
-        self.widgetId = createWidget.widgetId
-        createWidget.widgetId += 1
         #  K_UP,  K_DOWN,  K_LEFT,  and K_RIGHT
         self.widget.bind("<Button-3>", self.rightMouseDown)
         self.widget.bind("<Button-1>", self.leftMouseDown)
@@ -483,6 +496,11 @@ class createWidget:
     @staticmethod
     def _configure_grid_extent(parent_widget, state: GridGeometry) -> None:
         """Ensure newly addressed cells have useful size and resize weight."""
+        is_root_grid = parent_widget is createWidget.baseRoot
+        column_minsize = myVars.gridColMinsize if is_root_grid else 40
+        row_minsize = myVars.gridRowMinsize if is_root_grid else 24
+        column_pad = myVars.gridColPad if is_root_grid else 0
+        row_pad = myVars.gridRowPad if is_root_grid else 0
         try:
             for col in range(state.column, state.column + state.columnspan):
                 info = parent_widget.columnconfigure(col)
@@ -491,8 +509,8 @@ class createWidget:
                     parent_widget.columnconfigure(
                         col,
                         weight=1,
-                        minsize=myVars.gridColMinsize,
-                        pad=myVars.gridColPad,
+                        minsize=column_minsize,
+                        pad=column_pad,
                     )
             for row in range(state.row, state.row + state.rowspan):
                 info = parent_widget.rowconfigure(row)
@@ -501,8 +519,8 @@ class createWidget:
                     parent_widget.rowconfigure(
                         row,
                         weight=1,
-                        minsize=myVars.gridRowMinsize,
-                        pad=myVars.gridRowPad,
+                        minsize=row_minsize,
+                        pad=row_pad,
                     )
         except (tk.TclError, TypeError, ValueError):
             # Notebook tab frames and a few ttkbootstrap helper widgets do not

--- a/editWidget.py
+++ b/editWidget.py
@@ -295,6 +295,31 @@ class widgetEditPopup:
             log.debug("Adding f %s", str(f))
             myVars.widgetImageFilenames.append(f)
 
+    def _captureLayoutControls(self) -> None:
+        """Read current Layout controls before Apply or Save Default."""
+        for name in (
+            "row",
+            "column",
+            "columnspan",
+            "rowspan",
+            "padx",
+            "pady",
+            "ipadx",
+            "ipady",
+            "sticky",
+            "side",
+            "fill",
+            "expand",
+            "anchor",
+            "x",
+            "y",
+            "width",
+            "height",
+        ):
+            control = self.stringDict.get(name + "Widget")
+            if control is not None:
+                self.stringDict[name] = control.get()
+
     def applyLayoutSettings(self) -> None:
         """
         Apply changed layout for the Widget.
@@ -303,6 +328,7 @@ class widgetEditPopup:
         """
         logString = "Layout %s new value %s"
         log.debug("Apply Layout settings (geomManager=%s)", myVars.geomManager)
+        self._captureLayoutControls()
 
         if myVars.geomManager == "Grid":
             cwo = cw.findCreateWidgetObject(self.widgetName)
@@ -404,18 +430,6 @@ class widgetEditPopup:
         """Apply this Grid layout and save it for future widgets of this type."""
         if myVars.geomManager != "Grid":
             return
-        for name in (
-            "columnspan",
-            "rowspan",
-            "padx",
-            "pady",
-            "ipadx",
-            "ipady",
-            "sticky",
-        ):
-            control = self.stringDict.get(name + "Widget")
-            if control is not None:
-                self.stringDict[name] = control.get()
         self.applyLayoutSettings()
         cwo = cw.findCreateWidgetObject(self.widgetName)
         if cwo is None:
@@ -432,11 +446,14 @@ class widgetEditPopup:
             "sticky": state.sticky,
         }
         try:
-            path = tool_defaults.write(
+            path = tool_defaults.update_widget_layout(
                 tool_defaults.default_path(myVars.programName),
-                myVars.currentToolDefaults(),
+                widget_type,
+                myVars.gridWidgetDefaults[widget_type],
             )
-        except (OSError, TypeError) as exc:
+            saved_defaults = tool_defaults.read(path)
+            myVars.gridWidgetDefaults = saved_defaults["gridWidgetDefaults"]
+        except (OSError, TypeError, ValueError) as exc:
             Messagebox.show_error(
                 title="Cannot save layout default",
                 message=str(exc),
@@ -826,6 +843,31 @@ class widgetEditPopup:
         layoutPopupFrame.place(x=300, y=10)
         self.createDragPoint(layoutPopupFrame, "triangle")
 
+        # Match the Edit Attributes popup: actions stay visible above the
+        # fields rather than moving to the bottom as the form grows.
+        buttonBar = ttk.Frame(layoutPopupFrame)
+        buttonBar.grid(row=1, column=0, columnspan=4, sticky="ew", pady=(2, 5))
+        ttk.Button(
+            buttonBar,
+            style="warning",
+            text="Close",
+            command=layoutPopupFrame.destroy,
+        ).pack(side=tk.LEFT, expand=True, fill=tk.X, padx=2)
+        ttk.Button(
+            buttonBar,
+            style="success",
+            text="Apply",
+            command=self.applyLayoutSettings,
+        ).pack(side=tk.LEFT, expand=True, fill=tk.X, padx=2)
+        if myVars.geomManager == "Grid":
+            ttk.Button(
+                buttonBar,
+                style="info",
+                text="Save default",
+                command=self.saveLayoutAsTypeDefault,
+            ).pack(side=tk.LEFT, expand=True, fill=tk.X, padx=2)
+        gridRow = 1
+
         if myVars.geomManager == "Grid":
             # ---- Grid layout fields -----------------------------------
             # Read stored GeomData from our helper dict, or fall back to
@@ -1064,43 +1106,6 @@ class widgetEditPopup:
                 w.set(val)
                 lab1.grid(row=gridRow, column=0, sticky=tk.E)
                 w.grid(row=gridRow, column=3, sticky=tk.NSEW)
-
-        # blank spacer
-        gridRow += 1
-        lab2 = ttk.Label(layoutPopupFrame, text="  ")
-        lab2.grid(row=gridRow, column=2)
-        gridRow += 1
-        b1 = ttk.Button(
-            layoutPopupFrame,
-            style="warning",
-            width=5,
-            text="Close",
-            command=layoutPopupFrame.destroy,
-        )
-        b2 = ttk.Button(
-            layoutPopupFrame,
-            style="success",
-            width=5,
-            text="Apply",
-            command=self.applyLayoutSettings,
-        )
-
-        b1.grid(row=gridRow, column=0)
-        b2.grid(row=gridRow, column=3)
-        if myVars.geomManager == "Grid":
-            gridRow += 1
-            ttk.Button(
-                layoutPopupFrame,
-                style="info",
-                text="Save type default",
-                command=self.saveLayoutAsTypeDefault,
-            ).grid(
-                row=gridRow,
-                column=0,
-                columnspan=4,
-                sticky="ew",
-                pady=(4, 0),
-            )
 
     # Map each widget's lower-case tcl name (after fixWidgetName) to the best
     # available docs URL.  ttkbootstrap widgets go to the ttkbootstrap API docs;

--- a/editWidget.py
+++ b/editWidget.py
@@ -427,33 +427,50 @@ class widgetEditPopup:
                     log.warning("k %s val %s", str(p), str(newVal))
 
     def saveLayoutAsTypeDefault(self) -> None:
-        """Apply this Grid layout and save it for future widgets of this type."""
-        if myVars.geomManager != "Grid":
+        """Apply this layout and save type defaults for Grid or Place."""
+        manager = myVars.geomManager
+        if manager not in ("Grid", "Place"):
             return
         self.applyLayoutSettings()
-        cwo = cw.findCreateWidgetObject(self.widgetName)
-        if cwo is None:
-            return
-        state = cwo.capture_grid_geometry()
         widget_type = myVars.fixWidgetName(self.widget.widgetName).lower()
-        myVars.gridWidgetDefaults[widget_type] = {
-            "columnspan": state.columnspan,
-            "rowspan": state.rowspan,
-            "padx": state.padx,
-            "pady": state.pady,
-            "ipadx": state.ipadx,
-            "ipady": state.ipady,
-            "sticky": state.sticky,
-        }
         try:
-            path = tool_defaults.update_widget_layout(
-                tool_defaults.default_path(myVars.programName),
-                widget_type,
-                myVars.gridWidgetDefaults[widget_type],
+            path = tool_defaults.default_path(myVars.programName)
+            if manager == "Grid":
+                cwo = cw.findCreateWidgetObject(self.widgetName)
+                if cwo is None:
+                    return
+                state = cwo.capture_grid_geometry()
+                layout = {
+                    "columnspan": state.columnspan,
+                    "rowspan": state.rowspan,
+                    "padx": state.padx,
+                    "pady": state.pady,
+                    "ipadx": state.ipadx,
+                    "ipady": state.ipady,
+                    "sticky": state.sticky,
+                }
+                path = tool_defaults.update_widget_layout(
+                    path,
+                    widget_type,
+                    layout,
+                )
+            else:
+                place = self.widget.place_info()
+                layout = {
+                    "width": int(place.get("width") or self.widget.winfo_width()),
+                    "height": int(place.get("height") or self.widget.winfo_height()),
+                }
+                path = tool_defaults.update_place_widget_layout(
+                    path,
+                    widget_type,
+                    layout,
+                )
+            saved_defaults, _loaded_paths = tool_defaults.read_discovered(
+                myVars.programName
             )
-            saved_defaults = tool_defaults.read(path)
             myVars.gridWidgetDefaults = saved_defaults["gridWidgetDefaults"]
-        except (OSError, TypeError, ValueError) as exc:
+            myVars.placeWidgetDefaults = saved_defaults["placeWidgetDefaults"]
+        except (OSError, TypeError, ValueError, tk.TclError) as exc:
             Messagebox.show_error(
                 title="Cannot save layout default",
                 message=str(exc),
@@ -461,7 +478,7 @@ class widgetEditPopup:
             return
         Messagebox.show_info(
             title="Layout default saved",
-            message=f"Saved {widget_type} Grid defaults to {path}",
+            message=f"Saved {widget_type} {manager} defaults to {path}",
         )
 
     def applyEditSettings(self) -> None:
@@ -843,29 +860,37 @@ class widgetEditPopup:
         layoutPopupFrame.place(x=300, y=10)
         self.createDragPoint(layoutPopupFrame, "triangle")
 
-        # Match the Edit Attributes popup: actions stay visible above the
-        # fields rather than moving to the bottom as the form grows.
-        buttonBar = ttk.Frame(layoutPopupFrame)
-        buttonBar.grid(row=1, column=0, columnspan=4, sticky="ew", pady=(2, 5))
-        ttk.Button(
-            buttonBar,
-            style="warning",
-            text="Close",
-            command=layoutPopupFrame.destroy,
-        ).pack(side=tk.LEFT, expand=True, fill=tk.X, padx=2)
-        ttk.Button(
-            buttonBar,
-            style="success",
-            text="Apply",
-            command=self.applyLayoutSettings,
-        ).pack(side=tk.LEFT, expand=True, fill=tk.X, padx=2)
-        if myVars.geomManager == "Grid":
+        def _add_button_bar(bar_row: int, pady) -> None:
+            buttonBar = ttk.Frame(layoutPopupFrame)
+            buttonBar.grid(
+                row=bar_row,
+                column=0,
+                columnspan=4,
+                sticky="ew",
+                pady=pady,
+            )
             ttk.Button(
                 buttonBar,
-                style="info",
-                text="Save default",
-                command=self.saveLayoutAsTypeDefault,
+                style="warning",
+                text="Close",
+                command=layoutPopupFrame.destroy,
             ).pack(side=tk.LEFT, expand=True, fill=tk.X, padx=2)
+            ttk.Button(
+                buttonBar,
+                style="success",
+                text="Apply",
+                command=self.applyLayoutSettings,
+            ).pack(side=tk.LEFT, expand=True, fill=tk.X, padx=2)
+            if myVars.geomManager in ("Grid", "Place"):
+                ttk.Button(
+                    buttonBar,
+                    style="info",
+                    text="Save default",
+                    command=self.saveLayoutAsTypeDefault,
+                ).pack(side=tk.LEFT, expand=True, fill=tk.X, padx=2)
+
+        # Duplicate actions above and below the form so either end is convenient.
+        _add_button_bar(1, (2, 5))
         gridRow = 1
 
         if myVars.geomManager == "Grid":
@@ -939,6 +964,7 @@ class widgetEditPopup:
                 w.set(val)
                 lab1.grid(row=gridRow, column=0, sticky=tk.E)
                 w.grid(row=gridRow, column=3, sticky=tk.NSEW)
+
             # sticky combobox
             gridRow += 1
             lab1 = ttk.Label(layoutPopupFrame, text="sticky")
@@ -1107,6 +1133,8 @@ class widgetEditPopup:
                 lab1.grid(row=gridRow, column=0, sticky=tk.E)
                 w.grid(row=gridRow, column=3, sticky=tk.NSEW)
 
+        _add_button_bar(gridRow + 1, (5, 2))
+
     # Map each widget's lower-case tcl name (after fixWidgetName) to the best
     # available docs URL.  ttkbootstrap widgets go to the ttkbootstrap API docs;
     # plain tk widgets go to the standard tkinter reference.
@@ -1180,28 +1208,36 @@ class widgetEditPopup:
         editPopupFrame.place(x=300, y=10)
         self.createDragPoint(editPopupFrame, "triangle")
 
-        # Keep actions outside the scrolling area and at the top so they are
-        # always reachable, even for widgets with a long attribute list.
-        buttonBar = ttk.Frame(editPopupFrame)
-        buttonBar.grid(row=1, column=0, columnspan=7, sticky="ew", pady=(2, 4))
-        ttk.Button(
-            buttonBar,
-            style="warning",
-            text="Close",
-            command=editPopupFrame.destroy,
-        ).pack(side=tk.LEFT, expand=True, fill=tk.X, padx=2)
-        ttk.Button(
-            buttonBar,
-            style="info",
-            text="Help",
-            command=self.getHelp,
-        ).pack(side=tk.LEFT, expand=True, fill=tk.X, padx=2)
-        ttk.Button(
-            buttonBar,
-            style="success",
-            text="Apply",
-            command=self.applyEditSettings,
-        ).pack(side=tk.LEFT, expand=True, fill=tk.X, padx=2)
+        def _add_button_bar(bar_row: int, pady) -> None:
+            buttonBar = ttk.Frame(editPopupFrame)
+            buttonBar.grid(
+                row=bar_row,
+                column=0,
+                columnspan=7,
+                sticky="ew",
+                pady=pady,
+            )
+            ttk.Button(
+                buttonBar,
+                style="warning",
+                text="Close",
+                command=editPopupFrame.destroy,
+            ).pack(side=tk.LEFT, expand=True, fill=tk.X, padx=2)
+            ttk.Button(
+                buttonBar,
+                style="info",
+                text="Help",
+                command=self.getHelp,
+            ).pack(side=tk.LEFT, expand=True, fill=tk.X, padx=2)
+            ttk.Button(
+                buttonBar,
+                style="success",
+                text="Apply",
+                command=self.applyEditSettings,
+            ).pack(side=tk.LEFT, expand=True, fill=tk.X, padx=2)
+
+        # Keep actions outside the scrolling area at both ends.
+        _add_button_bar(1, (2, 4))
 
         # ---- Scrollable content area ------------------------------------
         # Height is computed from the number of attribute rows so there is
@@ -1682,3 +1718,5 @@ class widgetEditPopup:
             self.addToStringDict(widgetKey2, tl_entry)
             tl_entry.insert(tk.END, val2)
             tl_entry.grid(row=gridRow, column=controlCol, columnspan=3, sticky=tk.NSEW)
+
+        _add_button_bar(3, (4, 2))

--- a/editWidget.py
+++ b/editWidget.py
@@ -7,11 +7,13 @@ from typing import Any
 import ttkbootstrap as ttk
 from PIL import ImageTk
 from tkfontchooser import askfont
+from ttkbootstrap.dialogs import Messagebox
 from ttkbootstrap.dialogs.colorchooser import ColorChooserDialog
 
 import createWidget as cw
 import project_format
 import pytkguivars as myVars
+import tool_defaults
 import undoredo
 
 stickyVals = [" ", tk.N, tk.S, tk.E, tk.W, tk.NS, tk.EW, tk.NSEW]
@@ -397,6 +399,53 @@ class widgetEditPopup:
                 except tk.TclError as e:
                     log.error(e)
                     log.warning("k %s val %s", str(p), str(newVal))
+
+    def saveLayoutAsTypeDefault(self) -> None:
+        """Apply this Grid layout and save it for future widgets of this type."""
+        if myVars.geomManager != "Grid":
+            return
+        for name in (
+            "columnspan",
+            "rowspan",
+            "padx",
+            "pady",
+            "ipadx",
+            "ipady",
+            "sticky",
+        ):
+            control = self.stringDict.get(name + "Widget")
+            if control is not None:
+                self.stringDict[name] = control.get()
+        self.applyLayoutSettings()
+        cwo = cw.findCreateWidgetObject(self.widgetName)
+        if cwo is None:
+            return
+        state = cwo.capture_grid_geometry()
+        widget_type = myVars.fixWidgetName(self.widget.widgetName).lower()
+        myVars.gridWidgetDefaults[widget_type] = {
+            "columnspan": state.columnspan,
+            "rowspan": state.rowspan,
+            "padx": state.padx,
+            "pady": state.pady,
+            "ipadx": state.ipadx,
+            "ipady": state.ipady,
+            "sticky": state.sticky,
+        }
+        try:
+            path = tool_defaults.write(
+                tool_defaults.default_path(myVars.programName),
+                myVars.currentToolDefaults(),
+            )
+        except (OSError, TypeError) as exc:
+            Messagebox.show_error(
+                title="Cannot save layout default",
+                message=str(exc),
+            )
+            return
+        Messagebox.show_info(
+            title="Layout default saved",
+            message=f"Saved {widget_type} Grid defaults to {path}",
+        )
 
     def applyEditSettings(self) -> None:
         """
@@ -1038,6 +1087,20 @@ class widgetEditPopup:
 
         b1.grid(row=gridRow, column=0)
         b2.grid(row=gridRow, column=3)
+        if myVars.geomManager == "Grid":
+            gridRow += 1
+            ttk.Button(
+                layoutPopupFrame,
+                style="info",
+                text="Save type default",
+                command=self.saveLayoutAsTypeDefault,
+            ).grid(
+                row=gridRow,
+                column=0,
+                columnspan=4,
+                sticky="ew",
+                pady=(4, 0),
+            )
 
     # Map each widget's lower-case tcl name (after fixWidgetName) to the best
     # available docs URL.  ttkbootstrap widgets go to the ttkbootstrap API docs;
@@ -1112,13 +1175,38 @@ class widgetEditPopup:
         editPopupFrame.place(x=300, y=10)
         self.createDragPoint(editPopupFrame, "triangle")
 
+        # Keep actions outside the scrolling area and at the top so they are
+        # always reachable, even for widgets with a long attribute list.
+        buttonBar = ttk.Frame(editPopupFrame)
+        buttonBar.grid(row=1, column=0, columnspan=7, sticky="ew", pady=(2, 4))
+        ttk.Button(
+            buttonBar,
+            style="warning",
+            text="Close",
+            command=editPopupFrame.destroy,
+        ).pack(side=tk.LEFT, expand=True, fill=tk.X, padx=2)
+        ttk.Button(
+            buttonBar,
+            style="info",
+            text="Help",
+            command=self.getHelp,
+        ).pack(side=tk.LEFT, expand=True, fill=tk.X, padx=2)
+        ttk.Button(
+            buttonBar,
+            style="success",
+            text="Apply",
+            command=self.applyEditSettings,
+        ).pack(side=tk.LEFT, expand=True, fill=tk.X, padx=2)
+
         # ---- Scrollable content area ------------------------------------
         # Height is computed from the number of attribute rows so there is
         # no wasted gap at the bottom.  A vertical scrollbar is shown only
         # when the content is taller than the maximum visible height.
         _ROW_PX = 26  # approximate pixels per attribute row
-        _MAX_H = 480  # maximum visible height before scrolling starts
-        _scroll_w = 320
+        topWin.update_idletasks()
+        _window_h = max(400, topWin.winfo_height())
+        _MAX_H = max(180, min(480, _window_h - 150))
+        _scroll_w = 280
 
         # Estimate row count: widget keys + any child-widget extra keys.
         # A precise count comes later but this is close enough for sizing.
@@ -1140,9 +1228,9 @@ class widgetEditPopup:
             editPopupFrame, orient="vertical", command=scrollCanvas.yview
         )
         scrollCanvas.configure(yscrollcommand=vscroll.set)
-        scrollCanvas.grid(row=1, column=0, columnspan=6, sticky="nsew")
+        scrollCanvas.grid(row=2, column=0, columnspan=6, sticky="nsew")
         if _need_scroll:
-            vscroll.grid(row=1, column=6, sticky="ns")
+            vscroll.grid(row=2, column=6, sticky="ns")
         scrollContent = ttk.Frame(scrollCanvas)
         _win_id = scrollCanvas.create_window((0, 0), window=scrollContent, anchor="nw")
 
@@ -1154,7 +1242,7 @@ class widgetEditPopup:
             content_h = scrollContent.winfo_reqheight()
             canvas_h = scrollCanvas.winfo_height()
             if content_h > canvas_h:
-                vscroll.grid(row=1, column=6, sticky="ns")
+                vscroll.grid(row=2, column=6, sticky="ns")
                 scrollCanvas.configure(yscrollcommand=vscroll.set)
             else:
                 vscroll.grid_remove()
@@ -1168,6 +1256,18 @@ class widgetEditPopup:
 
         scrollCanvas.bind("<MouseWheel>", _on_mousewheel)
         scrollContent.bind("<MouseWheel>", _on_mousewheel)
+        scrollCanvas.bind(
+            "<Button-4>", lambda _evt: scrollCanvas.yview_scroll(-1, "units")
+        )
+        scrollCanvas.bind(
+            "<Button-5>", lambda _evt: scrollCanvas.yview_scroll(1, "units")
+        )
+        scrollContent.bind(
+            "<Button-4>", lambda _evt: scrollCanvas.yview_scroll(-1, "units")
+        )
+        scrollContent.bind(
+            "<Button-5>", lambda _evt: scrollCanvas.yview_scroll(1, "units")
+        )
         # -------------------------------------------------------------------
         gridRow += 1
         keys = self.widget.keys()
@@ -1577,39 +1677,3 @@ class widgetEditPopup:
             self.addToStringDict(widgetKey2, tl_entry)
             tl_entry.insert(tk.END, val2)
             tl_entry.grid(row=gridRow, column=controlCol, columnspan=3, sticky=tk.NSEW)
-
-        gridRow += 1
-
-        b1 = ttk.Button(
-            editPopupFrame,
-            style="warning",
-            # width=4,
-            text="Close",
-            command=editPopupFrame.destroy,
-        )
-        b2 = ttk.Button(
-            editPopupFrame,
-            style="info",
-            # width=4,
-            text="Help",
-            command=self.getHelp,
-        )
-        b3 = ttk.Button(
-            editPopupFrame,
-            style="success",
-            # width=4,
-            text="Apply",
-            command=self.applyEditSettings,
-        )
-
-        # blank Label to make the layout better
-        lab2 = ttk.Label(editPopupFrame, text="   ")
-        lab2.grid(row=gridRow, column=2)
-
-        gridRow += 1
-        # b1.grid(row=gridRow, column=0, columnspan=2, sticky="EW")
-        # b2.grid(row=gridRow, column=2, columnspan=2, sticky="EW")
-        # b3.grid(row=gridRow, column=4, columnspan=2, sticky="EW")
-        b1.grid(row=gridRow, column=0, sticky="EW")
-        b2.grid(row=gridRow, column=2, sticky="EW")
-        b3.grid(row=gridRow, column=4, sticky="EW")

--- a/layout_model.py
+++ b/layout_model.py
@@ -12,6 +12,15 @@ from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
 from typing import Any
 
+GRID_CONTAINER_TYPES = (
+    "ttk::frame",
+    "ttk::labelframe",
+    "ttk::panedwindow",
+    "frame",
+    "labelframe",
+    "panedwindow",
+)
+
 
 def _as_int(value: Any, default: int) -> int:
     """Return a tolerant integer for values read from Tk or legacy JSON."""
@@ -23,6 +32,31 @@ def _as_int(value: Any, default: int) -> int:
         return int(str(value).split()[0])
     except (TypeError, ValueError):
         return default
+
+
+def is_grid_container_type(widget_type: Any) -> bool:
+    """Return whether *widget_type* can contain designer Grid children."""
+    return str(widget_type or "").lower() in GRID_CONTAINER_TYPES
+
+
+def container_grid_dimensions(
+    widget_data: Mapping[str, Any] | None,
+    default_columns: int = 4,
+    default_rows: int = 4,
+) -> tuple[int, int]:
+    """Return the persisted internal Grid dimensions for a container.
+
+    Older projects did not save this information, so they retain the
+    historical 4×4 container grid.
+    """
+    values = widget_data if isinstance(widget_data, Mapping) else {}
+    saved = values.get("ContainerGrid")
+    if not isinstance(saved, Mapping):
+        saved = {}
+    return (
+        max(1, _as_int(saved.get("columns"), default_columns)),
+        max(1, _as_int(saved.get("rows"), default_rows)),
+    )
 
 
 @dataclass(frozen=True)
@@ -136,14 +170,15 @@ def grid_layout_requirements(
             extent = requirements.setdefault(parent, [0, 0])
             extent[0] = max(extent[0], state.column + state.columnspan)
             extent[1] = max(extent[1], state.row + state.rowspan)
-        if widget_data.get("WidgetName") in (
-            "ttk::frame",
-            "ttk::labelframe",
-            "ttk::panedwindow",
-        ):
+        if is_grid_container_type(widget_data.get("WidgetName")):
+            saved_columns, saved_rows = container_grid_dimensions(
+                widget_data,
+                default_columns=container_columns,
+                default_rows=container_rows,
+            )
             container_extent = requirements.setdefault(widget_name, [0, 0])
-            container_extent[0] = max(container_extent[0], container_columns)
-            container_extent[1] = max(container_extent[1], container_rows)
+            container_extent[0] = max(container_extent[0], saved_columns)
+            container_extent[1] = max(container_extent[1], saved_rows)
     return {
         parent: (max(1, values[0]), max(1, values[1]))
         for parent, values in requirements.items()

--- a/layout_model.py
+++ b/layout_model.py
@@ -120,8 +120,8 @@ def grid_layout_requirements(
     """Return ``parent -> (column_count, row_count)`` for generated code."""
     requirements: dict[str, list[int]] = {
         root_name: [
-            max(2, _as_int(project_data.get("gridCols"), 10)),
-            max(2, _as_int(project_data.get("gridRows"), 10)),
+            max(2, _as_int(project_data.get("gridCols"), 25)),
+            max(2, _as_int(project_data.get("gridRows"), 25)),
         ]
     }
     for widget_name in widget_order:
@@ -148,3 +148,63 @@ def grid_layout_requirements(
         parent: (max(1, values[0]), max(1, values[1]))
         for parent, values in requirements.items()
     }
+
+
+def compact_grid_geometries(
+    states: Iterable[GridGeometry],
+    configured_columns: int,
+    configured_rows: int,
+    minimum_columns: int = 2,
+    minimum_rows: int = 2,
+) -> tuple[list[GridGeometry], int, int, int, int]:
+    """Close unused root-grid gaps and return new dimensions and removal counts."""
+    original = list(states)
+    if not original:
+        return (
+            [],
+            max(minimum_columns, configured_columns),
+            max(minimum_rows, configured_rows),
+            0,
+            0,
+        )
+
+    used_columns = {
+        column
+        for state in original
+        for column in range(state.column, state.column + state.columnspan)
+    }
+    used_rows = {
+        row for state in original for row in range(state.row, state.row + state.rowspan)
+    }
+    column_map = {
+        old_column: new_column
+        for new_column, old_column in enumerate(sorted(used_columns))
+    }
+    row_map = {old_row: new_row for new_row, old_row in enumerate(sorted(used_rows))}
+    compacted = [
+        state.updated(column=column_map[state.column], row=row_map[state.row])
+        for state in original
+    ]
+    column_count = max(
+        minimum_columns,
+        max(state.column + state.columnspan for state in compacted),
+    )
+    row_count = max(
+        minimum_rows,
+        max(state.row + state.rowspan for state in compacted),
+    )
+    old_column_count = max(
+        configured_columns,
+        max(state.column + state.columnspan for state in original),
+    )
+    old_row_count = max(
+        configured_rows,
+        max(state.row + state.rowspan for state in original),
+    )
+    return (
+        compacted,
+        column_count,
+        row_count,
+        max(0, old_column_count - column_count),
+        max(0, old_row_count - row_count),
+    )

--- a/project_format.py
+++ b/project_format.py
@@ -23,6 +23,28 @@ PRESERVED_STRING_KEYS = CALLBACK_KEYS + VARIABLE_KEYS
 RUNTIME_CALLABLE_KEYS = ("yscrollcommand", "xscrollcommand")
 
 
+def format_python_call(call_expression: str, arguments: Iterable[str]) -> str:
+    """Format a generated Python call with one argument per line."""
+    values = [str(value) for value in arguments if str(value)]
+    if not values:
+        return f"{call_expression}()"
+    body = "\n".join(f"    {value}," for value in values)
+    return f"{call_expression}(\n{body}\n)"
+
+
+def generated_python_dialog_defaults(
+    project_name: str,
+    save_directory: str,
+    generated_file: str,
+    home_directory: str,
+) -> tuple[str, str]:
+    """Return the last output directory and a project-derived Python name."""
+    previous_directory = os.path.dirname(generated_file) if generated_file else ""
+    directory = previous_directory or save_directory or home_directory
+    filename = (str(project_name).strip() or "project") + ".py"
+    return directory, filename
+
+
 def write_project_json(
     file_name: str,
     file_type: str,

--- a/pytkguivars.py
+++ b/pytkguivars.py
@@ -9,7 +9,7 @@ import ttkbootstrap as ttk
 import createWidget as cw
 import project_format
 import tool_defaults
-from layout_model import GridGeometry
+from layout_model import GridGeometry, is_grid_container_type
 
 # import cdefs as C
 # import io
@@ -309,6 +309,15 @@ def saveWidgetAsDict(widgetName) -> dict:
             "Place": place,
             "GeomData": geomData,
         }
+        if geomManager == "Grid" and is_grid_container_type(w.widgetName):
+            try:
+                container_columns, container_rows = w.grid_size()
+            except tk.TclError:
+                container_columns, container_rows = 4, 4
+            widgetDict["ContainerGrid"] = {
+                "columns": str(max(1, int(container_columns))),
+                "rows": str(max(1, int(container_rows))),
+            }
         keyCount = 0
         # Guard against stale / already-destroyed widget paths.  This can
         # happen when an undo snapshot is taken for a child widget whose parent

--- a/pytkguivars.py
+++ b/pytkguivars.py
@@ -109,6 +109,7 @@ gridColMinsize = tool_defaults.GRID_DEFAULTS["gridColMinsize"]
 gridRowPad = tool_defaults.GRID_DEFAULTS["gridRowPad"]
 gridColPad = tool_defaults.GRID_DEFAULTS["gridColPad"]
 gridWidgetDefaults = tool_defaults.normalise_widget_layouts(None)
+placeWidgetDefaults = tool_defaults.normalise_place_widget_layouts(None)
 # ---- Widget groups (logical, not tkinter containers) --------------------
 # {group_name: [widgetName, ...]}  — persisted to project JSON
 groups: dict = {}
@@ -161,7 +162,7 @@ def initVars():
     global selectedWidgets
     global gridRows, gridCols, gridLineColor
     global gridRowMinsize, gridColMinsize, gridRowPad, gridColPad
-    global gridWidgetDefaults
+    global gridWidgetDefaults, placeWidgetDefaults
     groups = {}
     selectedWidgets = []
     gridRows = tool_defaults.GRID_DEFAULTS["gridRows"]
@@ -173,13 +174,14 @@ def initVars():
     gridRowPad = tool_defaults.GRID_DEFAULTS["gridRowPad"]
     gridColPad = tool_defaults.GRID_DEFAULTS["gridColPad"]
     gridWidgetDefaults = tool_defaults.normalise_widget_layouts(None)
+    placeWidgetDefaults = tool_defaults.normalise_place_widget_layouts(None)
 
 
 def applyToolDefaults(data: dict) -> None:
     """Apply a validated tool-defaults dictionary to the live settings."""
     global gridRows, gridCols, gridLineColor
     global gridRowMinsize, gridColMinsize, gridRowPad, gridColPad
-    global gridWidgetDefaults
+    global gridWidgetDefaults, placeWidgetDefaults
     defaults = tool_defaults.normalise(data)
     gridRows = defaults["gridRows"]
     gridCols = defaults["gridCols"]
@@ -189,10 +191,11 @@ def applyToolDefaults(data: dict) -> None:
     gridRowPad = defaults["gridRowPad"]
     gridColPad = defaults["gridColPad"]
     gridWidgetDefaults = defaults["gridWidgetDefaults"]
+    placeWidgetDefaults = defaults["placeWidgetDefaults"]
 
 
 def currentToolDefaults() -> dict:
-    """Return the current Grid settings in tool_defaults.json format."""
+    """Return the current geometry settings in tool_defaults.json format."""
     return {
         "gridRows": gridRows,
         "gridCols": gridCols,
@@ -202,12 +205,18 @@ def currentToolDefaults() -> dict:
         "gridRowPad": gridRowPad,
         "gridColPad": gridColPad,
         "gridWidgetDefaults": gridWidgetDefaults,
+        "placeWidgetDefaults": placeWidgetDefaults,
     }
 
 
 def gridDefaultsForWidget(widgetName: str) -> dict:
     """Return configured Grid defaults for a Tk widget type."""
     return tool_defaults.widget_layout(widgetName, gridWidgetDefaults)
+
+
+def placeDefaultsForWidget(widgetName: str) -> dict:
+    """Return configured Place dimensions for a Tk widget type."""
+    return tool_defaults.place_size(widgetName, placeWidgetDefaults)
 
 
 # Common Procs
@@ -277,7 +286,7 @@ def saveWidgetAsDict(widgetName) -> dict:
             # Pack/Grid widgets are not in .place() — place_info() may raise
             # TclError if the widget path is stale.  Log and continue; geomData
             # will capture the real geometry below.
-            log.warning("place_info() on ->%s<- raised %s (ignored)", str(w), str(ex))
+            log.debug("place_info() on ->%s<- raised %s (ignored)", str(w), str(ex))
         # Capture geometry info for all supported managers
         geomData = {}
         try:
@@ -325,11 +334,12 @@ def saveWidgetAsDict(widgetName) -> dict:
         try:
             keys = w.keys()
         except tk.TclError as _ke:
-            log.warning(
+            log.debug(
                 "saveWidgetAsDict: w.keys() failed for %s: %s (skipping attributes)",
                 widgetName,
                 _ke,
             )
+            widgetDict[widgetName + "-KeyCount"] = 0
             return {widgetName: widgetDict}
         # Keys whose values are bound Python callables (e.g. scrollbar.set,
         # canvas.yview).  Tkinter returns them as strings like
@@ -443,20 +453,37 @@ def buildAWidget(widgetId: object, wDictOrig: dict) -> str:
     t = fixWidgetTypeName(wType)
     wType = t
     keyCount = widgetName + "-KeyCount"
-
-    nKeys = 0
-
+    raw_key_count = wDict.get(keyCount)
     try:
-        nKeys = wDict[keyCount]
-    except KeyError as e:
-        log.error("KeyError in json? ->%s<- ->%s<- %s", keyCount, str(nKeys), e)
+        nKeys = max(0, int(raw_key_count))
+    except (TypeError, ValueError):
+        log.error(
+            "buildAWidget: %s has missing/invalid attribute count %r; "
+            "rebuilding %s without saved attributes (available keys: %s)",
+            keyCount,
+            raw_key_count,
+            widgetName,
+            sorted(wDict),
+        )
+        nKeys = 0
 
     widgetDef = wType + "(mainFrame"
     for a in range(nKeys):
         attribute = "Attribute" + str(a)
-        aDict = wDict[attribute]
-        key = aDict["Key"]
-        val = aDict["Value"]
+        aDict = wDict.get(attribute)
+        if not isinstance(aDict, dict):
+            log.error(
+                "buildAWidget: %s declares %d attributes but %s is missing/invalid",
+                widgetName,
+                nKeys,
+                attribute,
+            )
+            continue
+        key = str(aDict.get("Key", ""))
+        val = str(aDict.get("Value", ""))
+        if not key:
+            log.error("buildAWidget: %s has no Key value", attribute)
+            continue
         useValQuotes = True
         if key == "image":
             if val:

--- a/pytkguivars.py
+++ b/pytkguivars.py
@@ -102,6 +102,7 @@ geomManager = "Grid"
 # The grid auto-expands if more rows/cols are needed.
 gridRows: int = 25
 gridCols: int = 25
+gridLineColor: str = ""
 gridRowMinsize = "2.5m"  # 2.5 mm
 gridColMinsize = "5m"  # 5 mm
 gridRowPad = "2.5m"
@@ -156,11 +157,13 @@ def initVars():
     generatedPyFile = ""
     global groups
     global selectedWidgets
-    global gridRows, gridCols
+    global gridRows, gridCols, gridLineColor
     groups = {}
     selectedWidgets = []
-    gridRows = 10
-    gridCols = 10
+    gridRows = 25
+    gridCols = 25
+    # Empty means use a readable foreground from the active tool theme.
+    gridLineColor = ""
 
 
 # Common Procs

--- a/pytkguivars.py
+++ b/pytkguivars.py
@@ -8,6 +8,7 @@ import ttkbootstrap as ttk
 
 import createWidget as cw
 import project_format
+import tool_defaults
 from layout_model import GridGeometry
 
 # import cdefs as C
@@ -100,13 +101,14 @@ GEOM_MANAGERS = ("Place", "Grid", "Pack")
 geomManager = "Grid"
 # Number of rows/columns in the initial grid (Grid mode only).
 # The grid auto-expands if more rows/cols are needed.
-gridRows: int = 25
-gridCols: int = 25
-gridLineColor: str = ""
-gridRowMinsize = "2.5m"  # 2.5 mm
-gridColMinsize = "5m"  # 5 mm
-gridRowPad = "2.5m"
-gridColPad = "5m"
+gridRows: int = tool_defaults.GRID_DEFAULTS["gridRows"]
+gridCols: int = tool_defaults.GRID_DEFAULTS["gridCols"]
+gridLineColor: str = tool_defaults.GRID_DEFAULTS["gridLineColor"]
+gridRowMinsize = tool_defaults.GRID_DEFAULTS["gridRowMinsize"]
+gridColMinsize = tool_defaults.GRID_DEFAULTS["gridColMinsize"]
+gridRowPad = tool_defaults.GRID_DEFAULTS["gridRowPad"]
+gridColPad = tool_defaults.GRID_DEFAULTS["gridColPad"]
+gridWidgetDefaults = tool_defaults.normalise_widget_layouts(None)
 # ---- Widget groups (logical, not tkinter containers) --------------------
 # {group_name: [widgetName, ...]}  — persisted to project JSON
 groups: dict = {}
@@ -158,12 +160,54 @@ def initVars():
     global groups
     global selectedWidgets
     global gridRows, gridCols, gridLineColor
+    global gridRowMinsize, gridColMinsize, gridRowPad, gridColPad
+    global gridWidgetDefaults
     groups = {}
     selectedWidgets = []
-    gridRows = 25
-    gridCols = 25
+    gridRows = tool_defaults.GRID_DEFAULTS["gridRows"]
+    gridCols = tool_defaults.GRID_DEFAULTS["gridCols"]
     # Empty means use a readable foreground from the active tool theme.
-    gridLineColor = ""
+    gridLineColor = tool_defaults.GRID_DEFAULTS["gridLineColor"]
+    gridRowMinsize = tool_defaults.GRID_DEFAULTS["gridRowMinsize"]
+    gridColMinsize = tool_defaults.GRID_DEFAULTS["gridColMinsize"]
+    gridRowPad = tool_defaults.GRID_DEFAULTS["gridRowPad"]
+    gridColPad = tool_defaults.GRID_DEFAULTS["gridColPad"]
+    gridWidgetDefaults = tool_defaults.normalise_widget_layouts(None)
+
+
+def applyToolDefaults(data: dict) -> None:
+    """Apply a validated tool-defaults dictionary to the live settings."""
+    global gridRows, gridCols, gridLineColor
+    global gridRowMinsize, gridColMinsize, gridRowPad, gridColPad
+    global gridWidgetDefaults
+    defaults = tool_defaults.normalise(data)
+    gridRows = defaults["gridRows"]
+    gridCols = defaults["gridCols"]
+    gridLineColor = defaults["gridLineColor"]
+    gridRowMinsize = defaults["gridRowMinsize"]
+    gridColMinsize = defaults["gridColMinsize"]
+    gridRowPad = defaults["gridRowPad"]
+    gridColPad = defaults["gridColPad"]
+    gridWidgetDefaults = defaults["gridWidgetDefaults"]
+
+
+def currentToolDefaults() -> dict:
+    """Return the current Grid settings in tool_defaults.json format."""
+    return {
+        "gridRows": gridRows,
+        "gridCols": gridCols,
+        "gridLineColor": gridLineColor,
+        "gridRowMinsize": gridRowMinsize,
+        "gridColMinsize": gridColMinsize,
+        "gridRowPad": gridRowPad,
+        "gridColPad": gridColPad,
+        "gridWidgetDefaults": gridWidgetDefaults,
+    }
+
+
+def gridDefaultsForWidget(widgetName: str) -> dict:
+    """Return configured Grid defaults for a Tk widget type."""
+    return tool_defaults.widget_layout(widgetName, gridWidgetDefaults)
 
 
 # Common Procs

--- a/pytkquickgui.py
+++ b/pytkquickgui.py
@@ -52,16 +52,19 @@ def _toolDefaultsPath() -> str:
 
 
 def loadToolDefaults() -> None:
-    """Load tool-wide Grid defaults, falling back to shipped values."""
-    defaults = tool_defaults.read(_toolDefaultsPath())
+    """Load layered tool-wide geometry defaults."""
+    defaults, loaded_paths = tool_defaults.read_discovered(myVars.programName)
     myVars.applyToolDefaults(defaults)
-    log.info("Loaded Grid tool defaults from %s", _toolDefaultsPath())
+    if loaded_paths:
+        log.info("Loaded tool defaults from %s", ", ".join(loaded_paths))
+    else:
+        log.info("Using built-in tool defaults")
 
 
 def saveToolDefaults() -> str:
-    """Persist the current Grid settings as defaults for future projects."""
+    """Persist current tool settings in the user's highest-priority file."""
     path = tool_defaults.write(_toolDefaultsPath(), myVars.currentToolDefaults())
-    log.info("Saved Grid tool defaults to %s", path)
+    log.info("Saved tool defaults to %s", path)
     return path
 
 
@@ -640,7 +643,7 @@ def buildPython() -> str:
     # Deduplicate function names (a command may appear on multiple widgets)
     seen_funcs: set = set()
 
-    log.warning("functions ->%s<-", functions)
+    log.debug("functions ->%s<-", functions)
     for f in functions:
         if not f or f in seen_funcs:
             continue
@@ -685,9 +688,22 @@ def buildPython() -> str:
             wType = wDict.get("WidgetName")
             t = myVars.fixWidgetTypeName(wType)
             wType = t
-            keyCount = widgetName + "-KeyCount"
             widgetArguments = [parentName]
-            nKeys = wDict.get(keyCount)
+            keyCount = widgetName + "-KeyCount"
+            raw_key_count = wDict.get(keyCount)
+            try:
+                nKeys = max(0, int(raw_key_count))
+            except (TypeError, ValueError):
+                log.error(
+                    "buildPython: %s has missing/invalid attribute count %r; "
+                    "generating %s without saved attributes "
+                    "(available keys: %s)",
+                    keyCount,
+                    raw_key_count,
+                    widgetName,
+                    sorted(wDict),
+                )
+                nKeys = 0
             specialKeys = [
                 "postcommand",
                 "command",
@@ -699,8 +715,20 @@ def buildPython() -> str:
                 useValQuotes = True
                 attribute = "Attribute" + str(a)
                 aDict = wDict.get(attribute)
-                key = aDict.get("Key")
-                val = aDict.get("Value")
+                if not isinstance(aDict, dict):
+                    log.error(
+                        "buildPython: %s declares %d attributes but %s "
+                        "is missing/invalid",
+                        widgetName,
+                        nKeys,
+                        attribute,
+                    )
+                    continue
+                key = str(aDict.get("Key", ""))
+                val = str(aDict.get("Value", ""))
+                if not key:
+                    log.error("buildPython: %s has no Key value", attribute)
+                    continue
                 if key in specialKeys:
                     useValQuotes = False
                 if key in project_format.PRESERVED_STRING_KEYS:
@@ -1132,12 +1160,21 @@ def newProject():
     if not name:
         return
 
-    # New projects start from the saved tool-wide Grid settings.
+    # New projects start from the layered tool-wide geometry settings.
     loadToolDefaults()
     # Ask for geometry manager (and grid dimensions) once at project creation
     geom_choice, grid_rows, grid_cols = _askGeomManager()
     if not geom_choice:
         return
+
+    # Clear live Tk widgets and every parallel registry before destroying the
+    # old geometry frame.  Rebuilding the frame first leaves dead Tcl paths in
+    # widgetList/widgetNameList and causes later re-parent/save operations to
+    # call place_info() on widgets that no longer exist.
+    deleteWidgetData()
+    myVars.groups = {}
+    myVars.selectedWidgets = []
+    undoredo.stack.clear()
 
     # Keep the last output directory, but never preserve functions from a
     # different project's previously generated Python file.
@@ -1153,7 +1190,7 @@ def newProject():
     myVars.projectFileName = fileName
     log.info("projectFileName %s", myVars.projectFileName)
 
-    # Apply geometry manager (canvas is empty so setGeomManager will accept it)
+    # Apply geometry manager after the old project has been fully cleared.
     myVars.geomManager = geom_choice
     if geom_choice == "Grid":
         myVars.gridRows = grid_rows
@@ -1161,6 +1198,7 @@ def newProject():
     _rebuild_canvas_for_geom()
     _refresh_grid_toolbar()
     mainFrame.config(text=myVars.projectName)
+    myVars.projectSaved = False
 
 
 def _askGeomManager() -> tuple:
@@ -1196,9 +1234,8 @@ def _askGeomManager() -> tuple:
     grid_frame = ttk.Frame(top, padding=(24, 4, 24, 4))
     grid_frame.pack(fill="x")
 
-    have_tool_defaults = os.path.isfile(_toolDefaultsPath())
-    rows_var = tk.IntVar(value=myVars.gridRows if have_tool_defaults else 20)
-    cols_var = tk.IntVar(value=myVars.gridCols if have_tool_defaults else 20)
+    rows_var = tk.IntVar(value=myVars.gridRows)
+    cols_var = tk.IntVar(value=myVars.gridCols)
 
     rows_label = ttk.Label(grid_frame, text="Initial grid rows:")
     rows_spin = ttk.Spinbox(grid_frame, from_=2, to=50, textvariable=rows_var, width=6)
@@ -1648,13 +1685,7 @@ def loadProject(project, altFileName):
         # the saved colour values are discarded.  We must apply them again
         # immediately after the widget is created, before the theme has
         # a chance to override them a second time.
-        _nkeys = wDict.get(widgetId + "-KeyCount", 0)
-        for _ai in range(_nkeys):
-            _adict = wDict.get("Attribute" + str(_ai))
-            if _adict is None:
-                continue
-            _ck = _adict.get("Key", "")
-            _cv = _adict.get("Value", "")
+        for _ck, _cv in project_format.iter_attributes(widgetId, wDict):
             if _ck in _colour_keys and _cv and not _cv.startswith("<"):
                 try:
                     widget.configure(**{_ck: _cv})
@@ -3282,11 +3313,14 @@ def _configure_root_grid(widget, reset: bool = False):
         )
 
 
-def _placeNewWidget(w, x: int, y: int, width: int = 72, height: int = 32) -> None:
+def _placeNewWidget(w, x: int, y: int) -> None:
     """Position a newly created widget according to the active geometry manager."""
     mgr = myVars.geomManager
     if mgr == "Place":
-        w.place(x=x, y=y, width=width, height=height)
+        defaults = myVars.placeDefaultsForWidget(
+            w.widgetName if hasattr(w, "widgetName") else ""
+        )
+        w.place(x=x, y=y, **defaults)
     elif mgr == "Grid":
         # Map pixel click to grid cell using grid_location (exact) or fallback.
         parent = geomWidgetFrame if geomWidgetFrame is not None else mainCanvas
@@ -3507,7 +3541,7 @@ def createWidgetPopup(event, widgetName):
         w = ttk.Panedwindow(_parent, orient=tk.HORIZONTAL)
     """
     cw.createWidget(_parent, w)
-    _placeNewWidget(w, x, y, width=72, height=32)
+    _placeNewWidget(w, x, y)
 
 
 def rightMouseDown(event):

--- a/pytkquickgui.py
+++ b/pytkquickgui.py
@@ -570,13 +570,26 @@ def buildPython() -> str:
     print("import tkinter as tk\nimport ttkbootstrap as ttk\n")
     themeName = myVars.theme
     title = myVars.projectName
-    print("themeName = '" + themeName + "'\n")
-    print("title = '" + title + "'\n")
-    print("rootWin = ttk.Window(theme=themeName, title=title)")
+    print(f"themeName = {themeName!r}\n")
+    print(f"title = {title!r}\n")
+    print(
+        project_format.format_python_call(
+            "rootWin = ttk.Window",
+            ("theme=themeName", "title=title"),
+        )
+    )
     rootName = myVars.rootWidgetName
     print(
-        rootName
-        + " = ttk.Frame(rootWin, width=40, height=100, relief='ridge', borderwidth=1)"
+        project_format.format_python_call(
+            rootName + " = ttk.Frame",
+            (
+                "rootWin",
+                "width=40",
+                "height=100",
+                "relief='ridge'",
+                "borderwidth=1",
+            ),
+        )
     )
 
     def _emit_grid_configuration(parent_name: str) -> None:
@@ -673,7 +686,7 @@ def buildPython() -> str:
             t = myVars.fixWidgetTypeName(wType)
             wType = t
             keyCount = widgetName + "-KeyCount"
-            widgetDef = widgetName + " = " + wType + "(" + parentName
+            widgetArguments = [parentName]
             nKeys = wDict.get(keyCount)
             specialKeys = [
                 "postcommand",
@@ -718,13 +731,18 @@ def buildPython() -> str:
                 if len(val) > 0:
                     # keys are not consistent ...
                     if useValQuotes:
-                        tmpWidgetDef = widgetDef + ", " + key + "=" + repr(val)
+                        argument = key + "=" + repr(val)
                     else:
                         if key == "image":
                             val = str(widgetName) + key
-                        tmpWidgetDef = widgetDef + ", " + key + "=" + val
-                    widgetDef = tmpWidgetDef
-            print(widgetDef + ")")
+                        argument = key + "=" + val
+                    widgetArguments.append(argument)
+            print(
+                project_format.format_python_call(
+                    widgetName + " = " + wType,
+                    widgetArguments,
+                )
+            )
             if myVars.geomManager == "Grid":
                 _emit_grid_configuration(widgetName)
             geomData = wDict.get("GeomData", {})
@@ -748,9 +766,17 @@ def buildPython() -> str:
                 anchor = place.get("anchor", "nw")
                 bordermode = place.get("bordermode", "inside")
                 print(
-                    f"{widgetName}.place(x={x}, y={y}, width={width},"
-                    f" height={height}, anchor='{anchor}',"
-                    f" bordermode='{bordermode}')"
+                    project_format.format_python_call(
+                        f"{widgetName}.place",
+                        (
+                            f"x={x}",
+                            f"y={y}",
+                            f"width={width}",
+                            f"height={height}",
+                            f"anchor={anchor!r}",
+                            f"bordermode={bordermode!r}",
+                        ),
+                    )
                 )
             elif myVars.geomManager == "Grid":
                 row = geomData.get("row", "0")
@@ -762,18 +788,30 @@ def buildPython() -> str:
                 pady = geomData.get("pady", "2")
                 ipadx = int(geomData.get("ipadx", 0))
                 ipady = int(geomData.get("ipady", 0))
-                extra_args = ""
+                grid_arguments = [
+                    f"row={row}",
+                    f"column={col}",
+                ]
                 if columnspan > 1:
-                    extra_args += f", columnspan={columnspan}"
+                    grid_arguments.append(f"columnspan={columnspan}")
                 if rowspan > 1:
-                    extra_args += f", rowspan={rowspan}"
+                    grid_arguments.append(f"rowspan={rowspan}")
                 if ipadx:
-                    extra_args += f", ipadx={ipadx}"
+                    grid_arguments.append(f"ipadx={ipadx}")
                 if ipady:
-                    extra_args += f", ipady={ipady}"
+                    grid_arguments.append(f"ipady={ipady}")
+                grid_arguments.extend(
+                    (
+                        f"sticky={sticky!r}",
+                        f"padx={padx}",
+                        f"pady={pady}",
+                    )
+                )
                 print(
-                    f"{widgetName}.grid(row={row}, column={col}{extra_args},"
-                    f" sticky='{sticky}', padx={padx}, pady={pady})"
+                    project_format.format_python_call(
+                        f"{widgetName}.grid",
+                        grid_arguments,
+                    )
                 )
             elif myVars.geomManager == "Pack":
                 side = geomData.get("side", "top")
@@ -783,12 +821,21 @@ def buildPython() -> str:
                 pady = geomData.get("pady", "2")
                 anchor = geomData.get("anchor", "center")
                 print(
-                    f"{widgetName}.pack(side='{side}', fill='{fill}',"
-                    f" expand={expand}, padx={padx}, pady={pady},"
-                    f" anchor='{anchor}')"
+                    project_format.format_python_call(
+                        f"{widgetName}.pack",
+                        (
+                            f"side={side!r}",
+                            f"fill={fill!r}",
+                            f"expand={expand}",
+                            f"padx={padx}",
+                            f"pady={pady}",
+                            f"anchor={anchor!r}",
+                        ),
+                    )
                 )
             else:
                 log.error("Unknown geometry manager %s", myVars.geomManager)
+            print("")
     # For Grid mode the Place-coord accumulation above produces zeros/wrong
     # values.  Use the actual geomWidgetFrame size instead.
     if myVars.geomManager == "Grid" and geomWidgetFrame is not None:
@@ -820,11 +867,26 @@ def buildPython() -> str:
     print("sg0 = ttk.Sizegrip(rootWin)")
     print("sg0.grid(row=1, sticky=tk.SE)")
     if myVars.geomManager == "Place":
-        print(rootName + ".place(x=0, y=0, relwidth=1.0, relheight=1.0)")
+        print(
+            project_format.format_python_call(
+                rootName + ".place",
+                ("x=0", "y=0", "relwidth=1.0", "relheight=1.0"),
+            )
+        )
     elif myVars.geomManager == "Grid":
-        print(rootName + ".grid(row=0, column=0, sticky='NSEW')")
+        print(
+            project_format.format_python_call(
+                rootName + ".grid",
+                ("row=0", "column=0", "sticky='NSEW'"),
+            )
+        )
     elif myVars.geomManager == "Pack":
-        print(rootName + ".pack(fill='both', expand=True)")
+        print(
+            project_format.format_python_call(
+                rootName + ".pack",
+                ("fill='both'", "expand=True"),
+            )
+        )
     print("\nrootWin.mainloop()")
     _sys.stdout.close()
     _sys.stdout = _sys.__stdout__
@@ -849,18 +911,16 @@ def generatePython():
     The chosen path is stored in myVars.generatedPyFile so that the next
     call to buildPython() can load and preserve any user edits.
     """
-    # If we already know a target file, pre-fill the dialog with it.
-    home = os.environ["HOME"]
-    initialDir = myVars.saveDirName if myVars.saveDirName else home
-    initialFile = (
-        os.path.basename(myVars.generatedPyFile)
-        if myVars.generatedPyFile
-        else myVars.projectName + ".py"
+    # Reuse the last output directory, but always derive the filename from the
+    # current project instead of carrying over another project's filename.
+    initialDir, initialFile = project_format.generated_python_dialog_defaults(
+        myVars.projectName,
+        myVars.saveDirName,
+        myVars.generatedPyFile,
+        os.environ["HOME"],
     )
     newFile = tk.filedialog.asksaveasfilename(
-        initialdir=initialFile
-        and os.path.dirname(myVars.generatedPyFile)
-        or initialDir,
+        initialdir=initialDir,
         initialfile=initialFile,
         filetypes=[("Python file", "*.py")],
         defaultextension="py",
@@ -1079,6 +1139,9 @@ def newProject():
     if not geom_choice:
         return
 
+    # Keep the last output directory, but never preserve functions from a
+    # different project's previously generated Python file.
+    myVars.generatedPyFile = ""
     path = os.path.join(configPath, name)
     # Create directory only if it doesn't already exist
     os.makedirs(path, exist_ok=True)
@@ -1443,6 +1506,10 @@ def loadProject(project, altFileName):
 
     mainFrame.config(text=myVars.projectName)
     deleteWidgetData()
+    # A different or empty project must not inherit callback bodies from the
+    # previously generated file. Its directory remains available separately
+    # in saveDirName for the next Generate dialog.
+    myVars.generatedPyFile = ""
     projectTheme = myVars.theme
     data = _loadProjectData(fullFileName)
     if data is None:
@@ -1606,8 +1673,19 @@ def loadProject(project, altFileName):
         # configuration so child widgets can be reparented into them.
         if myVars.geomManager == "Grid":
             wn = wDict.get("WidgetName", "")
-            if wn in myVars.containerWidgetsUsed:
-                _configure_container_grid(widget)
+            if layout_model.is_grid_container_type(wn):
+                container_columns, container_rows = (
+                    layout_model.container_grid_dimensions(
+                        wDict,
+                        default_columns=_CONTAINER_GRID_COLS,
+                        default_rows=_CONTAINER_GRID_ROWS,
+                    )
+                )
+                _configure_container_grid(
+                    widget,
+                    columns=container_columns,
+                    rows=container_rows,
+                )
 
         # Apply the saved geometry for every manager.  This block used to be
         # indented inside the Grid-only container setup, which meant Place and
@@ -3154,7 +3232,11 @@ def _refresh_grid_toolbar() -> None:
             pass
 
 
-def _configure_container_grid(widget):
+def _configure_container_grid(
+    widget,
+    columns: int = _CONTAINER_GRID_COLS,
+    rows: int = _CONTAINER_GRID_ROWS,
+):
     """Give a container widget its own internal grid so child widgets can
     be reparented into it using Grid layout.
 
@@ -3165,9 +3247,9 @@ def _configure_container_grid(widget):
     Cells expand with the container so ``sticky='nsew'`` behaves the same in
     the designer and generated code.
     """
-    for c in range(_CONTAINER_GRID_COLS):
+    for c in range(max(1, int(columns))):
         widget.columnconfigure(c, weight=1, minsize=40)
-    for r in range(_CONTAINER_GRID_ROWS):
+    for r in range(max(1, int(rows))):
         widget.rowconfigure(r, weight=1, minsize=24)
 
 
@@ -3654,12 +3736,15 @@ def buildMainGui():
         spinbox.bind("<Return>", _apply_grid_dimensions)
         spinbox.bind("<FocusOut>", _apply_grid_dimensions)
 
-    gridColorButton = ttk.Menubutton(toolbarFrame, text="Grid colour")
+    gridColorButton = ttk.Menubutton(toolbarFrame, text="Grid settings")
     gridColorMenu = ttk.Menu(gridColorButton, tearoff=0)
-    gridColorMenu.add_command(label="Choose…", command=chooseGridColor)
-    gridColorMenu.add_command(label="Use theme colour", command=useThemeGridColor)
+    gridColorMenu.add_command(label="Choose guide colour…", command=chooseGridColor)
+    gridColorMenu.add_command(
+        label="Use theme guide colour",
+        command=useThemeGridColor,
+    )
     gridColorMenu.add_separator()
-    gridColorMenu.add_command(label="Grid settings…", command=editGridSettings)
+    gridColorMenu.add_command(label="Edit Grid settings…", command=editGridSettings)
     gridColorButton.configure(menu=gridColorMenu)
     gridColorButton.pack(side=tk.LEFT)
     _gridToolbarWidgets = [gridRowsSpin, gridColsSpin, gridColorButton]

--- a/pytkquickgui.py
+++ b/pytkquickgui.py
@@ -161,6 +161,9 @@ _grid_drag_state: dict = {}
 # Re-entrancy guard: prevents drawGridLines() from triggering itself via
 # mainCanvas.update() → <Configure> → drawGridLines() → recursion.
 _drawing_grid_lines: bool = False
+_gridRowsVar = None
+_gridColsVar = None
+_gridToolbarWidgets: list = []
 
 
 def setTheme(theme: object):
@@ -169,9 +172,45 @@ def setTheme(theme: object):
     log.debug(theme)
     # style = ttk.Style(rootWin)
     myVars.style.theme_use(theme)
+    _sync_grid_overlay_style()
+    drawGridLines()
     # for color_label in style.colors:
     #     color = style.colors.get(color_label)
     #     print(color_label,color)
+
+
+def _theme_grid_background() -> str:
+    """Return the active ttk theme's normal frame background."""
+    try:
+        color = ttk.Style().lookup("TFrame", "background")
+        if color:
+            return str(color)
+    except tk.TclError:
+        pass
+    return str(rootWin.cget("background"))
+
+
+def _current_grid_line_color() -> str:
+    custom = str(getattr(myVars, "gridLineColor", "") or "")
+    if custom:
+        return custom
+    try:
+        color = ttk.Style().lookup("TLabel", "foreground")
+        if color:
+            return str(color)
+    except tk.TclError:
+        pass
+    return "#808080"
+
+
+def _sync_grid_overlay_style() -> None:
+    if _gridOverlayCanvas is None:
+        return
+    try:
+        if _gridOverlayCanvas.winfo_exists():
+            _gridOverlayCanvas.configure(background=_theme_grid_background())
+    except tk.TclError:
+        pass
 
 
 def tree():
@@ -309,8 +348,9 @@ def saveProject():
         "height": height,
         "theme": myVars.theme,
         "geomManager": myVars.geomManager,
-        "gridRows": getattr(myVars, "gridRows", 10),
-        "gridCols": getattr(myVars, "gridCols", 10),
+        "gridRows": getattr(myVars, "gridRows", 25),
+        "gridCols": getattr(myVars, "gridCols", 25),
+        "gridLineColor": getattr(myVars, "gridLineColor", ""),
         "generatedPyFile": myVars.generatedPyFile,
         "widgetNameList": cleanList,
         "backgroundColor": myVars.backgroundColor,
@@ -1028,9 +1068,8 @@ def newProject():
     if geom_choice == "Grid":
         myVars.gridRows = grid_rows
         myVars.gridCols = grid_cols
-    if hasattr(rootWin, "_geomLabel"):
-        rootWin._geomLabel.config(text="Layout: " + geom_choice)
     _rebuild_canvas_for_geom()
+    _refresh_grid_toolbar()
     mainFrame.config(text=myVars.projectName)
 
 
@@ -1393,11 +1432,10 @@ def loadProject(project, altFileName):
         savedGeom = runDict.get("geomManager")
         if savedGeom and savedGeom in myVars.GEOM_MANAGERS:
             myVars.geomManager = savedGeom
-            if hasattr(rootWin, "_geomLabel"):
-                rootWin._geomLabel.config(text="Layout: " + savedGeom)
-        # Restore grid dimensions (default 10×10 for projects saved before this feature)
-        myVars.gridRows = int(runDict.get("gridRows", 10))
-        myVars.gridCols = int(runDict.get("gridCols", 10))
+        # Restore grid dimensions (default 25×25 for older project files).
+        myVars.gridRows = int(runDict.get("gridRows", 25))
+        myVars.gridCols = int(runDict.get("gridCols", 25))
+        myVars.gridLineColor = str(runDict.get("gridLineColor", "") or "")
         savedPyFile = runDict.get("generatedPyFile", "")
         if savedPyFile and os.path.isfile(savedPyFile):
             myVars.generatedPyFile = savedPyFile
@@ -1415,6 +1453,7 @@ def loadProject(project, altFileName):
     # Rebuild the canvas inner frame BEFORE creating widgets so they land in
     # the correct (new) geomWidgetFrame for the loaded project's geometry manager.
     _rebuild_canvas_for_geom()
+    _refresh_grid_toolbar()
 
     # Build the ordered list of widget IDs to load from widgetNameList.
     # This handles projects saved after deletions where IDs are non-contiguous
@@ -1461,7 +1500,10 @@ def loadProject(project, altFileName):
         except TypeError as e:
             log.error("%s dict %s eval() TypeError %s", widgetId, str(wDict), str(e))
             continue
-        w = cw.createWidget(_load_parent, widget)
+        # Assign the persisted identity during construction. Renaming an
+        # auto-generated ID afterwards is unsafe when saved IDs contain gaps:
+        # a later auto-ID can collide with a name already restored earlier.
+        w = cw.createWidget(_load_parent, widget, python_name=widgetId)
 
         # Tab-frame fix: createWidget.__init__ calls widget.place(x,y) for
         # every widget in Place mode, including frames that are notebook tabs.
@@ -1485,21 +1527,6 @@ def loadProject(project, altFileName):
                         )
                     except tk.TclError as _pfe:
                         log.debug("load: place_forget on %s: %s", widgetId, _pfe)
-
-        # createWidget.__init__ auto-assigns pythonName = "Widget" + widgetId
-        # (starting from 0), which will be wrong for non-contiguous saved IDs.
-        # Correct the pythonName in both the object and the widgetNameList entry
-        # to match the saved name (e.g. "Widget2" instead of "Widget0").
-        if w.pythonName != widgetId:
-            _old_name = w.pythonName
-            # Find the auto-assigned entry and rename it
-            for _nl in cw.createWidget.widgetNameList:
-                if _nl[cw.NAME] == _old_name:
-                    _nl[cw.NAME] = widgetId
-                    break
-            w.pythonName = widgetId
-            w.widget.pythonName = widgetId
-            log.info("load: renamed auto-id %s → %s", _old_name, widgetId)
 
         # Post-construction colour restore: ttkbootstrap's theming engine
         # overrides bg=/background= kwargs during widget construction, so
@@ -1862,6 +1889,27 @@ def chooseBackground():
         mainCanvas.configure(bg=colors[1])
         mainCanvas.update()
         myVars.backgroundColor = colors[1]
+
+
+def chooseGridColor():
+    """Choose the guide-line and index-label colour for Grid projects."""
+    colors = askcolor(
+        color=_current_grid_line_color(),
+        title="Grid line colour",
+        parent=rootWin,
+    )
+    if colors[1] is None:
+        return
+    myVars.gridLineColor = colors[1]
+    myVars.projectSaved = False
+    drawGridLines()
+
+
+def useThemeGridColor():
+    """Return Grid guides to the foreground colour supplied by the theme."""
+    myVars.gridLineColor = ""
+    myVars.projectSaved = False
+    drawGridLines()
 
 
 def welcome():
@@ -2266,30 +2314,15 @@ def compactGrid() -> None:
     if geomWidgetFrame is None:
         return
 
-    # Collect all tracked widgets and their current grid positions from cwo.
-    widget_cwos = []
-    for obj in cw.createWidget.widgetObjectList:
-        if obj is None:
-            continue
-        # Only consider direct children of geomWidgetFrame (not nested)
-        try:
-            gi = obj.widget.grid_info()
-        except tk.TclError:
-            continue
-        if not gi:
-            continue  # not grid-managed (e.g. notebook tab frame)
-        # Check that this widget is a direct child of geomWidgetFrame.
-        # We compare Tk path strings:
-        #   • winfo_parent() returns the widget's actual Tk parent path — reliable
-        #     even when in_= was not used (so gi["in"] would be empty).
-        #   • gi.get("in", "") reflects the in_= grid option when it was supplied.
-        # Accept the widget if EITHER matches geomWidgetFrame's path string.
-        _gwf_path = str(geomWidgetFrame)
-        _in_path = str(gi.get("in", ""))
-        _parent_path = obj.widget.winfo_parent()
-        if _in_path != _gwf_path and _parent_path != _gwf_path:
-            continue
-        widget_cwos.append(obj)
+    # Every designer widget has the same physical Tk master, so winfo_parent()
+    # cannot distinguish root widgets from logical children. Use the canonical
+    # GridGeometry parent instead.
+    widget_cwos = [
+        obj
+        for obj in cw.createWidget.widgetObjectList
+        if obj is not None
+        and obj.capture_grid_geometry().parent == myVars.rootWidgetName
+    ]
 
     if not widget_cwos:
         Messagebox.show_info(
@@ -2298,24 +2331,18 @@ def compactGrid() -> None:
         )
         return
 
-    # Find which rows and columns are actually used.
-    used_cols: set = set()
-    used_rows: set = set()
-    for obj in widget_cwos:
-        for dc in range(obj.columnspan):
-            used_cols.add(obj.col + dc)
-        for dr in range(obj.rowspan):
-            used_rows.add(obj.row + dr)
-
-    # Build a sorted mapping from old → new index (gaps removed).
-    all_cols = sorted(used_cols)
-    all_rows = sorted(used_rows)
-    col_map = {old: new for new, old in enumerate(all_cols)}
-    row_map = {old: new for new, old in enumerate(all_rows)}
-
-    # Check if anything needs to change.
-    if all(col_map[c] == c for c in all_cols) and all(
-        row_map[r] == r for r in all_rows
+    old_states = [obj.capture_grid_geometry() for obj in widget_cwos]
+    new_states, new_cols, new_rows, n_cols_removed, n_rows_removed = (
+        layout_model.compact_grid_geometries(
+            old_states,
+            configured_columns=myVars.gridCols,
+            configured_rows=myVars.gridRows,
+        )
+    )
+    if (
+        old_states == new_states
+        and new_cols == myVars.gridCols
+        and new_rows == myVars.gridRows
     ):
         Messagebox.show_info(
             title="Compact Grid",
@@ -2323,29 +2350,13 @@ def compactGrid() -> None:
         )
         return
 
-    # Apply the new positions.
-    for obj in widget_cwos:
-        new_col = col_map.get(obj.col, obj.col)
-        new_row = row_map.get(obj.row, obj.row)
-        obj.col = new_col
-        obj.row = new_row
-        try:
-            obj.widget.grid(
-                row=new_row,
-                column=new_col,
-                columnspan=obj.columnspan,
-                rowspan=obj.rowspan,
-                sticky=obj.sticky,
-                padx=obj.padx,
-                pady=obj.pady,
-                ipadx=obj.ipadx,
-                ipady=obj.ipady,
-            )
-        except tk.TclError as e:
-            log.warning("compactGrid: grid() on %s failed: %s", obj.pythonName, e)
+    for obj, state in zip(widget_cwos, new_states):
+        obj.apply_grid_geometry(state, parent_widget=geomWidgetFrame)
 
-    n_cols_removed = len(set(range(max(used_cols) + 1)) - used_cols)
-    n_rows_removed = len(set(range(max(used_rows) + 1)) - used_rows)
+    myVars.gridCols = new_cols
+    myVars.gridRows = new_rows
+    _configure_root_grid(geomWidgetFrame, reset=True)
+    _refresh_grid_toolbar()
     myVars.projectSaved = False
     drawGridLines()
     log.info(
@@ -2479,6 +2490,7 @@ def _make_grid_overlay(frame: ttk.Frame) -> tk.Canvas:  # type: ignore[name-defi
             pass
     oc = tk.Canvas(
         frame,
+        background=_theme_grid_background(),
         highlightthickness=0,
         bd=0,
         takefocus=False,
@@ -2516,6 +2528,9 @@ def _grid_collect_lines(frame, oc_w, oc_h):
         n_cols, n_rows = frame.grid_size()
     except tk.TclError:
         n_cols, n_rows = 0, 0
+    if frame is geomWidgetFrame:
+        n_cols = max(2, int(myVars.gridCols))
+        n_rows = max(2, int(myVars.gridRows))
 
     col_xs = {0}
     for col in range(n_cols):
@@ -2793,12 +2808,8 @@ def _drawGridLines_impl():
 
         oc.delete("gridline")
 
-        line_color = "#c0c0c0"
-        label_color = "#a0a0a0"
-        # handle_color and add_color may be intridyced later
-        # handle_color = "#7090c0"  # blue-grey handles on interior dividers
-        # add_color = "#50b050"  # green "+" add buttons
-
+        line_color = _current_grid_line_color()
+        label_color = line_color
         col_xs, row_ys = _grid_collect_lines(geomWidgetFrame, oc_w, oc_h)
 
         # --- Draw vertical column-boundary lines ---
@@ -2873,6 +2884,57 @@ _CONTAINER_GRID_COLS = 4
 _CONTAINER_GRID_ROWS = 4
 
 
+def _minimum_root_grid_extent() -> tuple[int, int]:
+    columns = 2
+    rows = 2
+    for obj in cw.createWidget.widgetObjectList:
+        if obj is None:
+            continue
+        state = obj.capture_grid_geometry()
+        if state.parent != myVars.rootWidgetName:
+            continue
+        columns = max(columns, state.column + state.columnspan)
+        rows = max(rows, state.row + state.rowspan)
+    return columns, rows
+
+
+def _apply_grid_dimensions(_event=None) -> None:
+    """Apply toolbar row/column counts without hiding occupied cells."""
+    if myVars.geomManager != "Grid" or _gridRowsVar is None or _gridColsVar is None:
+        return
+    try:
+        requested_rows = max(2, min(100, int(_gridRowsVar.get())))
+        requested_cols = max(2, min(100, int(_gridColsVar.get())))
+    except (tk.TclError, TypeError, ValueError):
+        _refresh_grid_toolbar()
+        return
+    minimum_cols, minimum_rows = _minimum_root_grid_extent()
+    myVars.gridRows = max(requested_rows, minimum_rows)
+    myVars.gridCols = max(requested_cols, minimum_cols)
+    _gridRowsVar.set(myVars.gridRows)
+    _gridColsVar.set(myVars.gridCols)
+    if geomWidgetFrame is not None:
+        _configure_root_grid(geomWidgetFrame, reset=True)
+    myVars.projectSaved = False
+    drawGridLines()
+
+
+def _refresh_grid_toolbar() -> None:
+    """Synchronize toolbar controls with the active project."""
+    if hasattr(rootWin, "_geomLabel"):
+        rootWin._geomLabel.configure(text=myVars.geomManager)
+    if _gridRowsVar is not None:
+        _gridRowsVar.set(int(myVars.gridRows))
+    if _gridColsVar is not None:
+        _gridColsVar.set(int(myVars.gridCols))
+    state = "normal" if myVars.geomManager == "Grid" else "disabled"
+    for widget in _gridToolbarWidgets:
+        try:
+            widget.configure(state=state)
+        except tk.TclError:
+            pass
+
+
 def _configure_container_grid(widget):
     """Give a container widget its own internal grid so child widgets can
     be reparented into it using Grid layout.
@@ -2890,10 +2952,19 @@ def _configure_container_grid(widget):
         widget.rowconfigure(r, weight=1, minsize=24)
 
 
-def _configure_root_grid(widget):
+def _configure_root_grid(widget, reset: bool = False):
     """Configure exactly the user-requested initial Grid dimensions."""
-    columns = max(2, int(getattr(myVars, "gridCols", 10)))
-    rows = max(2, int(getattr(myVars, "gridRows", 10)))
+    columns = max(2, int(getattr(myVars, "gridCols", 25)))
+    rows = max(2, int(getattr(myVars, "gridRows", 25)))
+    if reset:
+        try:
+            old_columns, old_rows = widget.grid_size()
+        except tk.TclError:
+            old_columns, old_rows = columns, rows
+        for col in range(max(old_columns, columns)):
+            widget.columnconfigure(col, weight=0, minsize=0, pad=0)
+        for row in range(max(old_rows, rows)):
+            widget.rowconfigure(row, weight=0, minsize=0, pad=0)
     for col in range(columns):
         widget.columnconfigure(
             col,
@@ -3247,10 +3318,9 @@ def setGeomManager(mgr: str) -> None:
         return
     myVars.geomManager = mgr
     log.info("Geometry manager set to %s", mgr)
-    if hasattr(rootWin, "_geomLabel"):
-        rootWin._geomLabel.config(text="Layout: " + mgr)
     # Rebuild the canvas inner frame for the new manager
     _rebuild_canvas_for_geom()
+    _refresh_grid_toolbar()
 
 
 def _rebuild_canvas_for_geom():
@@ -3304,7 +3374,7 @@ def _rebuild_canvas_for_geom():
 
 
 def buildMainGui():
-    global mainFrame
+    global mainFrame, _gridRowsVar, _gridColsVar, _gridToolbarWidgets
 
     buildMenu()
 
@@ -3319,6 +3389,45 @@ def buildMainGui():
     geomLabel = ttk.Label(toolbarFrame, text=myVars.geomManager, bootstyle="info")
     geomLabel.pack(side=tk.LEFT, padx=(0, 8))
     rootWin._geomLabel = geomLabel
+
+    # Grid controls live beside the layout name so the drawn grid can be
+    # adjusted without starting a new project.
+    ttk.Label(toolbarFrame, text="Rows:").pack(side=tk.LEFT, padx=(0, 2))
+    _gridRowsVar = tk.IntVar(value=myVars.gridRows)
+    gridRowsSpin = ttk.Spinbox(
+        toolbarFrame,
+        from_=2,
+        to=100,
+        width=4,
+        textvariable=_gridRowsVar,
+        command=_apply_grid_dimensions,
+    )
+    gridRowsSpin.pack(side=tk.LEFT, padx=(0, 6))
+
+    ttk.Label(toolbarFrame, text="Cols:").pack(side=tk.LEFT, padx=(0, 2))
+    _gridColsVar = tk.IntVar(value=myVars.gridCols)
+    gridColsSpin = ttk.Spinbox(
+        toolbarFrame,
+        from_=2,
+        to=100,
+        width=4,
+        textvariable=_gridColsVar,
+        command=_apply_grid_dimensions,
+    )
+    gridColsSpin.pack(side=tk.LEFT, padx=(0, 8))
+
+    for spinbox in (gridRowsSpin, gridColsSpin):
+        spinbox.bind("<Return>", _apply_grid_dimensions)
+        spinbox.bind("<FocusOut>", _apply_grid_dimensions)
+
+    gridColorButton = ttk.Menubutton(toolbarFrame, text="Grid colour")
+    gridColorMenu = ttk.Menu(gridColorButton, tearoff=0)
+    gridColorMenu.add_command(label="Choose…", command=chooseGridColor)
+    gridColorMenu.add_command(label="Use theme colour", command=useThemeGridColor)
+    gridColorButton.configure(menu=gridColorMenu)
+    gridColorButton.pack(side=tk.LEFT)
+    _gridToolbarWidgets = [gridRowsSpin, gridColsSpin, gridColorButton]
+    _refresh_grid_toolbar()
 
     # ---- Undo/Redo status label (right side of toolbar) ---------------
     undoLabel = ttk.Label(

--- a/pytkquickgui.py
+++ b/pytkquickgui.py
@@ -18,12 +18,14 @@ import coloredlogs
 import tkfontchooser as tkfc
 import ttkbootstrap as ttk
 from ttkbootstrap.dialogs import Messagebox, Querybox
+from ttkbootstrap.dialogs.colorchooser import ColorChooserDialog
 
 import cdefs as C
 import createWidget as cw
 import layout_model
 import project_format
 import pytkguivars as myVars
+import tool_defaults
 import undoredo
 
 log = logging.getLogger(name="mylogger")
@@ -43,6 +45,24 @@ def getConfigPath() -> str:
         os.mkdir(configPath)
         log.info("Creating configPath %s", configPath)
     return configPath
+
+
+def _toolDefaultsPath() -> str:
+    return tool_defaults.default_path(myVars.programName)
+
+
+def loadToolDefaults() -> None:
+    """Load tool-wide Grid defaults, falling back to shipped values."""
+    defaults = tool_defaults.read(_toolDefaultsPath())
+    myVars.applyToolDefaults(defaults)
+    log.info("Loaded Grid tool defaults from %s", _toolDefaultsPath())
+
+
+def saveToolDefaults() -> str:
+    """Persist the current Grid settings as defaults for future projects."""
+    path = tool_defaults.write(_toolDefaultsPath(), myVars.currentToolDefaults())
+    log.info("Saved Grid tool defaults to %s", path)
+    return path
 
 
 def getDefaultTheme() -> str:
@@ -164,6 +184,7 @@ _drawing_grid_lines: bool = False
 _gridRowsVar = None
 _gridColsVar = None
 _gridToolbarWidgets: list = []
+_gridSyncAfterId = None
 
 
 def setTheme(theme: object):
@@ -351,6 +372,10 @@ def saveProject():
         "gridRows": getattr(myVars, "gridRows", 25),
         "gridCols": getattr(myVars, "gridCols", 25),
         "gridLineColor": getattr(myVars, "gridLineColor", ""),
+        "gridRowMinsize": myVars.gridRowMinsize,
+        "gridColMinsize": myVars.gridColMinsize,
+        "gridRowPad": myVars.gridRowPad,
+        "gridColPad": myVars.gridColPad,
         "generatedPyFile": myVars.generatedPyFile,
         "widgetNameList": cleanList,
         "backgroundColor": myVars.backgroundColor,
@@ -1047,6 +1072,8 @@ def newProject():
     if not name:
         return
 
+    # New projects start from the saved tool-wide Grid settings.
+    loadToolDefaults()
     # Ask for geometry manager (and grid dimensions) once at project creation
     geom_choice, grid_rows, grid_cols = _askGeomManager()
     if not geom_choice:
@@ -1106,8 +1133,9 @@ def _askGeomManager() -> tuple:
     grid_frame = ttk.Frame(top, padding=(24, 4, 24, 4))
     grid_frame.pack(fill="x")
 
-    rows_var = tk.IntVar(value=20)
-    cols_var = tk.IntVar(value=20)
+    have_tool_defaults = os.path.isfile(_toolDefaultsPath())
+    rows_var = tk.IntVar(value=myVars.gridRows if have_tool_defaults else 20)
+    cols_var = tk.IntVar(value=myVars.gridCols if have_tool_defaults else 20)
 
     rows_label = ttk.Label(grid_frame, text="Initial grid rows:")
     rows_spin = ttk.Spinbox(grid_frame, from_=2, to=50, textvariable=rows_var, width=6)
@@ -1342,6 +1370,9 @@ def _loadProjectData(fullFileName: str):
 
 def loadProject(project, altFileName):
     """Load a project from a saved file (JSON or legacy pickle)."""
+    # Establish tool defaults first; project-specific settings below override
+    # them when present.
+    loadToolDefaults()
     configPath = getConfigPath()
     folder = createFileName(configPath, None, project)
     fileName = ""
@@ -1415,9 +1446,16 @@ def loadProject(project, altFileName):
     projectTheme = myVars.theme
     data = _loadProjectData(fullFileName)
     if data is None:
-        # Brand new or empty project – just start fresh
+        # Rebuild the design surface as well as clearing the widget lists.
+        # Returning before this step left an empty Grid project blank until a
+        # widget drop or resize happened to force another redraw.
         log.info("No data found in %s – starting with empty canvas.", fullFileName)
+        _rebuild_canvas_for_geom()
+        _refresh_grid_toolbar()
         mainFrame.config(text=myVars.projectName)
+        _schedule_grid_sync()
+        undoredo.stack.clear()
+        myVars.projectSaved = True
         return
 
     try:
@@ -1432,10 +1470,20 @@ def loadProject(project, altFileName):
         savedGeom = runDict.get("geomManager")
         if savedGeom and savedGeom in myVars.GEOM_MANAGERS:
             myVars.geomManager = savedGeom
-        # Restore grid dimensions (default 25×25 for older project files).
-        myVars.gridRows = int(runDict.get("gridRows", 25))
-        myVars.gridCols = int(runDict.get("gridCols", 25))
-        myVars.gridLineColor = str(runDict.get("gridLineColor", "") or "")
+        # Older project files inherit the current tool-wide defaults.
+        myVars.gridRows = int(runDict.get("gridRows", myVars.gridRows))
+        myVars.gridCols = int(runDict.get("gridCols", myVars.gridCols))
+        myVars.gridLineColor = str(
+            runDict.get("gridLineColor", myVars.gridLineColor) or ""
+        )
+        myVars.gridRowMinsize = str(
+            runDict.get("gridRowMinsize", myVars.gridRowMinsize)
+        )
+        myVars.gridColMinsize = str(
+            runDict.get("gridColMinsize", myVars.gridColMinsize)
+        )
+        myVars.gridRowPad = str(runDict.get("gridRowPad", myVars.gridRowPad))
+        myVars.gridColPad = str(runDict.get("gridColPad", myVars.gridColPad))
         savedPyFile = runDict.get("generatedPyFile", "")
         if savedPyFile and os.path.isfile(savedPyFile):
             myVars.generatedPyFile = savedPyFile
@@ -1834,6 +1882,7 @@ def loadProject(project, altFileName):
     # Force tkinter to process all pending geometry requests so that
     # winfo_x() / winfo_y() return correct values immediately after load.
     rootWin.update_idletasks()
+    _schedule_grid_sync()
     # Clear undo history – actions from the old project aren't reachable
     undoredo.stack.clear()
     # A freshly loaded project has no unsaved changes yet
@@ -1893,14 +1942,13 @@ def chooseBackground():
 
 def chooseGridColor():
     """Choose the guide-line and index-label colour for Grid projects."""
-    colors = askcolor(
-        color=_current_grid_line_color(),
-        title="Grid line colour",
-        parent=rootWin,
-    )
-    if colors[1] is None:
+    colorDialog = ColorChooserDialog()
+    colorDialog.initialcolor = _current_grid_line_color()
+    colorDialog.show()
+    colors = colorDialog.result
+    if colors is None:
         return
-    myVars.gridLineColor = colors[1]
+    myVars.gridLineColor = colors[2] if colors[2] else ""
     myVars.projectSaved = False
     drawGridLines()
 
@@ -1910,6 +1958,177 @@ def useThemeGridColor():
     myVars.gridLineColor = ""
     myVars.projectSaved = False
     drawGridLines()
+
+
+def editGridSettings():
+    """Edit project Grid dimensions, guide colour, minsize, and padding."""
+    top = tk.Toplevel(rootWin)
+    top.title("Grid settings")
+    top.resizable(False, False)
+    top.transient(rootWin)
+
+    values = {
+        "gridRows": tk.StringVar(value=str(myVars.gridRows)),
+        "gridCols": tk.StringVar(value=str(myVars.gridCols)),
+        "gridRowMinsize": tk.StringVar(value=str(myVars.gridRowMinsize)),
+        "gridColMinsize": tk.StringVar(value=str(myVars.gridColMinsize)),
+        "gridRowPad": tk.StringVar(value=str(myVars.gridRowPad)),
+        "gridColPad": tk.StringVar(value=str(myVars.gridColPad)),
+        "gridLineColor": tk.StringVar(value=str(myVars.gridLineColor)),
+    }
+
+    fields = (
+        ("Rows drawn", "gridRows"),
+        ("Columns drawn", "gridCols"),
+        ("Row minsize", "gridRowMinsize"),
+        ("Column minsize", "gridColMinsize"),
+        ("Row pad", "gridRowPad"),
+        ("Column pad", "gridColPad"),
+    )
+    for row, (label, name) in enumerate(fields):
+        ttk.Label(top, text=label).grid(
+            row=row, column=0, sticky="e", padx=(10, 6), pady=3
+        )
+        if name in ("gridRows", "gridCols"):
+            control = ttk.Spinbox(
+                top, from_=2, to=100, width=8, textvariable=values[name]
+            )
+        else:
+            control = ttk.Entry(top, width=10, textvariable=values[name])
+        control.grid(row=row, column=1, sticky="ew", padx=(0, 10), pady=3)
+
+    colour_row = len(fields)
+    ttk.Label(top, text="Guide colour").grid(
+        row=colour_row, column=0, sticky="e", padx=(10, 6), pady=3
+    )
+    colourButton = ttk.Button(top, text="Select Color", bootstyle="secondary")
+
+    def _refresh_colour_button():
+        color = values["gridLineColor"].get()
+        colourButton.configure(text=color or "Use theme colour")
+        if color:
+            try:
+                colourButton.configure(background=color)
+            except tk.TclError:
+                pass
+
+    def _choose_colour():
+        colorDialog = ColorChooserDialog()
+        colorDialog.initialcolor = (
+            values["gridLineColor"].get() or _current_grid_line_color()
+        )
+        colorDialog.show()
+        colors = colorDialog.result
+        if colors is not None and colors[2]:
+            values["gridLineColor"].set(colors[2])
+            _refresh_colour_button()
+
+    colourButton.configure(command=_choose_colour)
+    colourButton.grid(row=colour_row, column=1, sticky="ew", padx=(0, 10), pady=3)
+    _refresh_colour_button()
+
+    def _use_theme_colour():
+        values["gridLineColor"].set("")
+        _refresh_colour_button()
+
+    ttk.Button(top, text="Theme colour", command=_use_theme_colour).grid(
+        row=colour_row + 1, column=1, sticky="ew", padx=(0, 10), pady=(0, 6)
+    )
+
+    def _apply() -> bool:
+        old_values = myVars.currentToolDefaults()
+        try:
+            requested_rows = max(2, min(100, int(values["gridRows"].get())))
+            requested_cols = max(2, min(100, int(values["gridCols"].get())))
+            distances = {
+                name: values[name].get().strip()
+                for name in (
+                    "gridRowMinsize",
+                    "gridColMinsize",
+                    "gridRowPad",
+                    "gridColPad",
+                )
+            }
+            for name, value in distances.items():
+                if not value or rootWin.winfo_pixels(value) < 0:
+                    raise ValueError(f"{name} must be a non-negative Tk distance")
+        except (tk.TclError, TypeError, ValueError) as exc:
+            Messagebox.show_error(
+                title="Invalid Grid setting",
+                message=str(exc),
+                parent=top,
+            )
+            return False
+
+        minimum_cols, minimum_rows = _minimum_root_grid_extent()
+        myVars.gridRows = max(requested_rows, minimum_rows)
+        myVars.gridCols = max(requested_cols, minimum_cols)
+        myVars.gridRowMinsize = distances["gridRowMinsize"]
+        myVars.gridColMinsize = distances["gridColMinsize"]
+        myVars.gridRowPad = distances["gridRowPad"]
+        myVars.gridColPad = distances["gridColPad"]
+        myVars.gridLineColor = values["gridLineColor"].get()
+        try:
+            if geomWidgetFrame is not None:
+                _configure_root_grid(geomWidgetFrame, reset=True)
+            _sync_grid_overlay_style()
+            _refresh_grid_toolbar()
+            myVars.projectSaved = False
+            _schedule_grid_sync()
+        except tk.TclError as exc:
+            myVars.applyToolDefaults(old_values)
+            if geomWidgetFrame is not None:
+                try:
+                    _configure_root_grid(geomWidgetFrame, reset=True)
+                except tk.TclError:
+                    pass
+            _sync_grid_overlay_style()
+            _refresh_grid_toolbar()
+            _schedule_grid_sync()
+            Messagebox.show_error(
+                title="Grid setting error",
+                message=str(exc),
+                parent=top,
+            )
+            return False
+        return True
+
+    def _save_as_default():
+        if not _apply():
+            return
+        try:
+            path = saveToolDefaults()
+        except (OSError, TypeError) as exc:
+            Messagebox.show_error(
+                title="Cannot save defaults",
+                message=str(exc),
+                parent=top,
+            )
+            return
+        Messagebox.show_info(
+            title="Grid defaults saved",
+            message=f"Saved to {path}",
+            parent=top,
+        )
+
+    buttonRow = ttk.Frame(top)
+    buttonRow.grid(
+        row=colour_row + 2, column=0, columnspan=2, sticky="ew", padx=8, pady=8
+    )
+    ttk.Button(buttonRow, text="Close", bootstyle="warning", command=top.destroy).pack(
+        side=tk.LEFT, expand=True, fill=tk.X, padx=2
+    )
+    ttk.Button(buttonRow, text="Apply", bootstyle="success", command=_apply).pack(
+        side=tk.LEFT, expand=True, fill=tk.X, padx=2
+    )
+    ttk.Button(
+        buttonRow,
+        text="Save as tool default",
+        bootstyle="info",
+        command=_save_as_default,
+    ).pack(side=tk.LEFT, expand=True, fill=tk.X, padx=2)
+
+    top.grab_set()
 
 
 def welcome():
@@ -2876,7 +3095,7 @@ def _drawGridLines_impl():
 
 def sizeGripRelease(event):
     log.debug(event)
-    drawGridLines()
+    _schedule_grid_sync()
 
 
 # ---- Grid layout: number of rows/columns pre-configured in each container ----
@@ -2916,7 +3135,7 @@ def _apply_grid_dimensions(_event=None) -> None:
     if geomWidgetFrame is not None:
         _configure_root_grid(geomWidgetFrame, reset=True)
     myVars.projectSaved = False
-    drawGridLines()
+    _schedule_grid_sync()
 
 
 def _refresh_grid_toolbar() -> None:
@@ -2997,18 +3216,9 @@ def _placeNewWidget(w, x: int, y: int, width: int = 72, height: int = 32) -> Non
             cell = 60
             col = max(0, x // cell)
             row = max(0, y // cell)
-        # Determine whether this widget is a container (Frame / Labelframe /
-        # Panedwindow).  Containers get a 2×2 default span; leaf widgets get 1×1.
-        _wname = (
-            myVars.fixWidgetName(w.widgetName).lower()
-            if hasattr(w, "widgetName")
-            else ""
+        defaults = myVars.gridDefaultsForWidget(
+            w.widgetName if hasattr(w, "widgetName") else ""
         )
-        _is_container = _wname in ("frame", "labelframe", "panedwindow")
-        col_span = 2 if _is_container else 1
-        row_span = 2 if _is_container else 1
-        # no auto-expansion — user sets sticky via Edit popup
-        new_sticky = "nsew"
         # Sync the authoritative cwo fields so drags and popups see the defaults.
         cwo = cw.findCreateWidgetObject(
             w.pythonName if hasattr(w, "pythonName") else ""
@@ -3018,9 +3228,7 @@ def _placeNewWidget(w, x: int, y: int, width: int = 72, height: int = 32) -> Non
                 parent=myVars.rootWidgetName,
                 row=row,
                 column=col,
-                columnspan=col_span,
-                rowspan=row_span,
-                sticky=new_sticky,
+                **defaults,
             )
             cwo.apply_grid_geometry(state, parent_widget=parent)
         else:
@@ -3028,11 +3236,7 @@ def _placeNewWidget(w, x: int, y: int, width: int = 72, height: int = 32) -> Non
                 in_=parent,
                 row=row,
                 column=col,
-                columnspan=col_span,
-                rowspan=row_span,
-                padx=2,
-                pady=2,
-                sticky=new_sticky,
+                **defaults,
             )
         # Re-lower the overlay canvas so it stays behind the new widget
         if _gridOverlayCanvas is not None:
@@ -3244,6 +3448,50 @@ def rightMouseDown(event):
         popup.grab_release()
 
 
+def _sync_geom_frame_to_canvas(event=None):
+    """Size the Grid design frame and overlay to the canvas's current area."""
+    if mainCanvas is None or not mainCanvas.winfo_exists():
+        return
+    if event is None:
+        mainCanvas.update_idletasks()
+        width = mainCanvas.winfo_width()
+        height = mainCanvas.winfo_height()
+    else:
+        width = event.width
+        height = event.height
+    if width < 2 or height < 2:
+        return
+    if geomWidgetFrame is not None and geomWidgetFrame.winfo_exists():
+        mainCanvas.itemconfigure("geomframe", width=width, height=height)
+        if _gridOverlayCanvas is not None and _gridOverlayCanvas.winfo_exists():
+            _gridOverlayCanvas.place(x=0, y=0, width=width, height=height)
+            tk.Misc.lower(_gridOverlayCanvas)
+        geomWidgetFrame.update_idletasks()
+    drawGridLines()
+
+
+def _schedule_grid_sync():
+    """Coalesce Grid synchronisation until Tk has completed geometry layout."""
+    global _gridSyncAfterId
+    if mainCanvas is None:
+        return
+    if _gridSyncAfterId is not None:
+        try:
+            mainCanvas.after_cancel(_gridSyncAfterId)
+        except tk.TclError:
+            pass
+
+    def _run():
+        global _gridSyncAfterId
+        _gridSyncAfterId = None
+        _sync_geom_frame_to_canvas()
+
+    try:
+        _gridSyncAfterId = mainCanvas.after_idle(_run)
+    except tk.TclError:
+        _gridSyncAfterId = None
+
+
 def buildGrid(rows, cols):
     """
     :rtype: object
@@ -3278,17 +3526,7 @@ def buildGrid(rows, cols):
         # they appear above the frame background but below child widgets).
         _make_grid_overlay(geomWidgetFrame)
 
-        # Expand the window when the canvas is resized; also redraw guides
-        def _resize_geom_frame(event):
-            mainCanvas.itemconfig("geomframe", width=event.width, height=event.height)
-            if _gridOverlayCanvas is not None:
-                _gridOverlayCanvas.place(
-                    x=0, y=0, width=event.width, height=event.height
-                )
-                tk.Misc.lower(_gridOverlayCanvas)
-            drawGridLines()
-
-        mainCanvas.bind("<Configure>", _resize_geom_frame)
+        mainCanvas.bind("<Configure>", _sync_geom_frame_to_canvas)
         cw.createWidget.baseRoot = geomWidgetFrame
     else:
         geomWidgetFrame = None
@@ -3296,7 +3534,11 @@ def buildGrid(rows, cols):
         # For Place mode, redraw dot grid on resize
         mainCanvas.bind("<Configure>", lambda e: drawGridLines())
 
-    drawGridLines()
+    # A canvas can receive its first Configure event before the inner frame
+    # and overlay exist. Map catches the first visible geometry; after_idle
+    # handles window managers that do not send another Configure event.
+    mainCanvas.bind("<Map>", lambda _event: _schedule_grid_sync(), add="+")
+    _schedule_grid_sync()
     # mainCanvas.bind('<Motion>',frameMove)
 
 
@@ -3355,22 +3597,14 @@ def _rebuild_canvas_for_geom():
         # Overlay canvas for grid guide-lines
         _make_grid_overlay(geomWidgetFrame)
 
-        def _resize_geom_frame(event):
-            mainCanvas.itemconfig("geomframe", width=event.width, height=event.height)
-            if _gridOverlayCanvas is not None:
-                _gridOverlayCanvas.place(
-                    x=0, y=0, width=event.width, height=event.height
-                )
-                tk.Misc.lower(_gridOverlayCanvas)
-            drawGridLines()
-
-        mainCanvas.bind("<Configure>", _resize_geom_frame)
+        mainCanvas.bind("<Configure>", _sync_geom_frame_to_canvas)
         cw.createWidget.baseRoot = geomWidgetFrame
     else:
         geomWidgetFrame = None
         cw.createWidget.baseRoot = mainCanvas
         mainCanvas.bind("<Configure>", lambda e: drawGridLines())
-    drawGridLines()
+    mainCanvas.bind("<Map>", lambda _event: _schedule_grid_sync(), add="+")
+    _schedule_grid_sync()
 
 
 def buildMainGui():
@@ -3424,6 +3658,8 @@ def buildMainGui():
     gridColorMenu = ttk.Menu(gridColorButton, tearoff=0)
     gridColorMenu.add_command(label="Choose…", command=chooseGridColor)
     gridColorMenu.add_command(label="Use theme colour", command=useThemeGridColor)
+    gridColorMenu.add_separator()
+    gridColorMenu.add_command(label="Grid settings…", command=editGridSettings)
     gridColorButton.configure(menu=gridColorMenu)
     gridColorButton.pack(side=tk.LEFT)
     _gridToolbarWidgets = [gridRowsSpin, gridColsSpin, gridColorButton]
@@ -3495,6 +3731,7 @@ if __name__ == "__main__":
     else:
         coloredlogs.set_level(logging.WARN)
     myVars.initVars()
+    loadToolDefaults()
     myVars.theme = useTheme
     log.info("mainFrame %s %s", mainFrame, str(mainFrame))
 

--- a/tests/test_layout_model.py
+++ b/tests/test_layout_model.py
@@ -101,6 +101,25 @@ class GridGeometryTests(unittest.TestCase):
             layout_model.is_saved_notebook_tab(project, "Widget3", "rootWidget")
         )
 
+    def test_compaction_closes_internal_and_trailing_grid_gaps(self):
+        states = [
+            layout_model.GridGeometry(row=0, column=0, columnspan=2),
+            layout_model.GridGeometry(row=4, column=5, rowspan=2),
+        ]
+
+        compacted, columns, rows, removed_columns, removed_rows = (
+            layout_model.compact_grid_geometries(
+                states,
+                configured_columns=10,
+                configured_rows=8,
+            )
+        )
+
+        self.assertEqual((compacted[0].row, compacted[0].column), (0, 0))
+        self.assertEqual((compacted[1].row, compacted[1].column), (1, 2))
+        self.assertEqual((columns, rows), (3, 3))
+        self.assertEqual((removed_columns, removed_rows), (7, 5))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_layout_model.py
+++ b/tests/test_layout_model.py
@@ -69,6 +69,7 @@ class GridGeometryTests(unittest.TestCase):
                 "WidgetName": "ttk::frame",
                 "WidgetParent": "rootWidget",
                 "GeomData": {"row": "1", "column": "2", "columnspan": "2"},
+                "ContainerGrid": {"columns": "7", "rows": "8"},
             },
             "Widget1": {
                 "WidgetName": "ttk::button",
@@ -94,12 +95,21 @@ class GridGeometryTests(unittest.TestCase):
         )
 
         self.assertEqual(requirements["rootWidget"], (4, 2))
-        self.assertEqual(requirements["Widget0"], (6, 6))
+        self.assertEqual(requirements["Widget0"], (7, 8))
         self.assertNotIn("Widget2", requirements)
         self.assertEqual(requirements["Widget3"], (4, 4))
         self.assertTrue(
             layout_model.is_saved_notebook_tab(project, "Widget3", "rootWidget")
         )
+
+    def test_container_grid_dimensions_are_persisted_with_legacy_fallback(self):
+        self.assertEqual(
+            layout_model.container_grid_dimensions(
+                {"ContainerGrid": {"columns": "9", "rows": "6"}}
+            ),
+            (9, 6),
+        )
+        self.assertEqual(layout_model.container_grid_dimensions({}), (4, 4))
 
     def test_compaction_closes_internal_and_trailing_grid_gaps(self):
         states = [

--- a/tests/test_project_format.py
+++ b/tests/test_project_format.py
@@ -22,6 +22,45 @@ class FakeWidget:
 
 
 class ProjectFormatTests(unittest.TestCase):
+    def test_generated_calls_are_readable_multiline_python(self):
+        formatted = project_format.format_python_call(
+            "Widget1 = ttk.Frame",
+            (
+                "rootWidget",
+                "width='0'",
+                "style='primary.TFrame'",
+            ),
+        )
+
+        self.assertEqual(
+            formatted,
+            "Widget1 = ttk.Frame(\n"
+            "    rootWidget,\n"
+            "    width='0',\n"
+            "    style='primary.TFrame',\n"
+            ")",
+        )
+
+    def test_generated_filename_uses_project_name_and_last_directory(self):
+        self.assertEqual(
+            project_format.generated_python_dialog_defaults(
+                "gridtest16",
+                "/tmp/older",
+                "/home/chris/previous-name.py",
+                "/home/chris",
+            ),
+            ("/home/chris", "gridtest16.py"),
+        )
+        self.assertEqual(
+            project_format.generated_python_dialog_defaults(
+                "new-project",
+                "/common/python",
+                "",
+                "/home/chris",
+            ),
+            ("/common/python", "new-project.py"),
+        )
+
     def test_callbacks_and_variables_survive_attribute_round_trip(self):
         data = widget_data(
             [

--- a/tests/test_tool_defaults.py
+++ b/tests/test_tool_defaults.py
@@ -44,6 +44,40 @@ class ToolDefaultsTests(unittest.TestCase):
         self.assertEqual(loaded["gridWidgetDefaults"]["label"]["sticky"], "ew")
         self.assertEqual(raw["formatVersion"], tool_defaults.FORMAT_VERSION)
 
+    def test_widget_update_preserves_manually_edited_grid_defaults(self):
+        supplied = {
+            "gridRows": 12,
+            "gridCols": 14,
+            "gridRowMinsize": "4m",
+            "gridColMinsize": "8m",
+            "gridRowPad": "1m",
+            "gridColPad": "2m",
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            path = os.path.join(directory, tool_defaults.FILE_NAME)
+            tool_defaults.write(path, supplied)
+            tool_defaults.update_widget_layout(
+                path,
+                "ttk::label",
+                {
+                    "columnspan": 4,
+                    "rowspan": 2,
+                    "padx": 3,
+                    "pady": 3,
+                    "ipadx": 0,
+                    "ipady": 0,
+                    "sticky": "ew",
+                },
+            )
+            loaded = tool_defaults.read(path)
+
+        self.assertEqual(loaded["gridRowMinsize"], "4m")
+        self.assertEqual(loaded["gridColMinsize"], "8m")
+        self.assertEqual(loaded["gridRowPad"], "1m")
+        self.assertEqual(loaded["gridColPad"], "2m")
+        self.assertEqual(loaded["gridWidgetDefaults"]["label"]["columnspan"], 4)
+        self.assertEqual(loaded["gridWidgetDefaults"]["label"]["rowspan"], 2)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_tool_defaults.py
+++ b/tests/test_tool_defaults.py
@@ -1,0 +1,49 @@
+import json
+import os
+import tempfile
+import unittest
+
+import tool_defaults
+
+
+class ToolDefaultsTests(unittest.TestCase):
+    def test_widget_layouts_have_useful_type_specific_spans(self):
+        label = tool_defaults.widget_layout("ttk::label")
+        text = tool_defaults.widget_layout("text")
+        frame = tool_defaults.widget_layout("ttk::frame")
+
+        self.assertEqual((label["columnspan"], label["rowspan"]), (2, 1))
+        self.assertEqual((text["columnspan"], text["rowspan"]), (5, 5))
+        self.assertEqual((frame["columnspan"], frame["rowspan"]), (5, 5))
+        label["columnspan"] = 99
+        self.assertEqual(
+            tool_defaults.widget_layout("ttk::label")["columnspan"],
+            2,
+        )
+
+    def test_saved_values_are_normalised_and_round_trip(self):
+        supplied = {
+            "gridRows": 1,
+            "gridCols": 150,
+            "gridRowMinsize": "3m",
+            "gridWidgetDefaults": {
+                "Label": {"columnspan": "4", "rowspan": 0, "sticky": "ew"}
+            },
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            path = os.path.join(directory, tool_defaults.FILE_NAME)
+            tool_defaults.write(path, supplied)
+            loaded = tool_defaults.read(path)
+            with open(path, "r", encoding="utf-8") as handle:
+                raw = json.load(handle)
+
+        self.assertEqual((loaded["gridRows"], loaded["gridCols"]), (2, 100))
+        self.assertEqual(loaded["gridRowMinsize"], "3m")
+        self.assertEqual(loaded["gridWidgetDefaults"]["label"]["columnspan"], 4)
+        self.assertEqual(loaded["gridWidgetDefaults"]["label"]["rowspan"], 1)
+        self.assertEqual(loaded["gridWidgetDefaults"]["label"]["sticky"], "ew")
+        self.assertEqual(raw["formatVersion"], tool_defaults.FORMAT_VERSION)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tool_defaults.py
+++ b/tests/test_tool_defaults.py
@@ -21,6 +21,15 @@ class ToolDefaultsTests(unittest.TestCase):
             2,
         )
 
+    def test_place_sizes_are_type_specific_and_detached(self):
+        button = tool_defaults.place_size("ttk::button")
+        text = tool_defaults.place_size("text")
+
+        self.assertEqual(button, {"width": 100, "height": 32})
+        self.assertEqual(text, {"width": 320, "height": 220})
+        text["width"] = 1
+        self.assertEqual(tool_defaults.place_size("text")["width"], 320)
+
     def test_saved_values_are_normalised_and_round_trip(self):
         supplied = {
             "gridRows": 1,
@@ -77,6 +86,95 @@ class ToolDefaultsTests(unittest.TestCase):
         self.assertEqual(loaded["gridColPad"], "2m")
         self.assertEqual(loaded["gridWidgetDefaults"]["label"]["columnspan"], 4)
         self.assertEqual(loaded["gridWidgetDefaults"]["label"]["rowspan"], 2)
+
+    def test_discovered_files_are_layered_in_documented_order(self):
+        with tempfile.TemporaryDirectory() as directory:
+            system = os.path.join(directory, "etc")
+            module = os.path.join(directory, "module")
+            current = os.path.join(directory, "current")
+            user = os.path.join(directory, "user", tool_defaults.FILE_NAME)
+            paths = tool_defaults.search_paths(
+                "pytkgui",
+                current_directory=current,
+                module_directory=module,
+                user_path=user,
+                system_directory=system,
+            )
+            for path, data in (
+                (
+                    paths[0],
+                    {
+                        "gridRows": 10,
+                        "gridWidgetDefaults": {"label": {"columnspan": 3}},
+                    },
+                ),
+                (
+                    paths[1],
+                    {
+                        "gridCols": 11,
+                        "placeWidgetDefaults": {"button": {"width": 150}},
+                    },
+                ),
+                (
+                    paths[2],
+                    {
+                        "gridRows": 12,
+                        "gridWidgetDefaults": {"label": {"rowspan": 2}},
+                    },
+                ),
+                (
+                    paths[3],
+                    {
+                        "gridRows": 14,
+                        "placeWidgetDefaults": {"button": {"height": 44}},
+                    },
+                ),
+            ):
+                os.makedirs(os.path.dirname(path), exist_ok=True)
+                with open(path, "w", encoding="utf-8") as handle:
+                    json.dump(data, handle)
+
+            loaded, loaded_paths = tool_defaults.read_discovered(
+                "pytkgui",
+                current_directory=current,
+                module_directory=module,
+                user_path=user,
+                system_directory=system,
+            )
+
+        self.assertEqual(loaded_paths, paths)
+        self.assertEqual((loaded["gridRows"], loaded["gridCols"]), (14, 11))
+        self.assertEqual(loaded["gridWidgetDefaults"]["label"]["columnspan"], 3)
+        self.assertEqual(loaded["gridWidgetDefaults"]["label"]["rowspan"], 2)
+        self.assertEqual(loaded["placeWidgetDefaults"]["button"]["width"], 150)
+        self.assertEqual(loaded["placeWidgetDefaults"]["button"]["height"], 44)
+
+    def test_place_update_preserves_other_manual_defaults(self):
+        supplied = {
+            "gridRowMinsize": "4m",
+            "placeWidgetDefaults": {
+                "label": {"width": 222, "height": 41},
+            },
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            path = os.path.join(directory, tool_defaults.FILE_NAME)
+            tool_defaults.write(path, supplied)
+            tool_defaults.update_place_widget_layout(
+                path,
+                "ttk::button",
+                {"width": 180, "height": 48},
+            )
+            loaded = tool_defaults.read(path)
+
+        self.assertEqual(loaded["gridRowMinsize"], "4m")
+        self.assertEqual(
+            loaded["placeWidgetDefaults"]["label"],
+            {"width": 222, "height": 41},
+        )
+        self.assertEqual(
+            loaded["placeWidgetDefaults"]["button"],
+            {"width": 180, "height": 48},
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_widget_persistence.py
+++ b/tests/test_widget_persistence.py
@@ -34,6 +34,13 @@ class FakeWidget:
         return self.values[key]
 
 
+class FakeContainer(FakeWidget):
+    widgetName = "ttk::frame"
+
+    def grid_size(self):
+        return 7, 6
+
+
 class FakeCreateWidget:
     def __init__(self, widget):
         self.pythonName = "Widget0"
@@ -111,6 +118,21 @@ class WidgetPersistenceTests(unittest.TestCase):
 
         self.assertEqual(attributes["command"], "run_report")
         self.assertEqual(attributes["textvariable"], "button_text")
+
+    def test_container_internal_grid_dimensions_are_saved(self):
+        self.widget = FakeContainer()
+        self.cwo = FakeCreateWidget(self.widget)
+        cw.createWidget.widgetNameList = [
+            ["Widget0", "rootWidget", self.widget, []],
+        ]
+        cw.createWidget.widgetObjectList = [self.cwo]
+
+        saved = my_vars.saveWidgetAsDict("Widget0")["Widget0"]
+
+        self.assertEqual(
+            saved["ContainerGrid"],
+            {"columns": "7", "rows": "6"},
+        )
 
     def test_plain_live_callback_is_migrated_to_explicit_metadata(self):
         self.widget._user_attrs = {}

--- a/tests/test_widget_persistence.py
+++ b/tests/test_widget_persistence.py
@@ -1,4 +1,5 @@
 import unittest
+import tkinter as tk
 
 import createWidget as cw
 import project_format
@@ -39,6 +40,14 @@ class FakeContainer(FakeWidget):
 
     def grid_size(self):
         return 7, 6
+
+
+class StaleWidget(FakeWidget):
+    def place_info(self):
+        raise tk.TclError("bad window path name")
+
+    def keys(self):
+        raise tk.TclError("invalid command name")
 
 
 class FakeCreateWidget:
@@ -143,6 +152,31 @@ class WidgetPersistenceTests(unittest.TestCase):
 
         self.assertEqual(attributes["command"], "run_report")
         self.assertEqual(self.widget._user_attrs["command"], "run_report")
+
+    def test_stale_widget_save_still_records_zero_attribute_count(self):
+        self.widget = StaleWidget()
+        self.cwo = FakeCreateWidget(self.widget)
+        cw.createWidget.widgetNameList = [
+            ["Widget0", "rootWidget", self.widget, []],
+        ]
+        cw.createWidget.widgetObjectList = [self.cwo]
+
+        saved = my_vars.saveWidgetAsDict("Widget0")["Widget0"]
+
+        self.assertEqual(saved["Widget0-KeyCount"], 0)
+        self.assertEqual(list(project_format.iter_attributes("Widget0", saved)), [])
+
+    def test_invalid_attribute_count_does_not_crash_widget_rebuild(self):
+        malformed = {
+            "WidgetName": "ttk::button",
+            "WidgetParent": "rootWidget",
+            "Widget0-KeyCount": None,
+        }
+
+        self.assertEqual(
+            my_vars.buildAWidget(0, malformed),
+            "ttk.Button(mainFrame)",
+        )
 
     def test_saved_identity_gaps_never_reuse_an_existing_name(self):
         old_counter = cw.createWidget.widgetId

--- a/tests/test_widget_persistence.py
+++ b/tests/test_widget_persistence.py
@@ -122,6 +122,29 @@ class WidgetPersistenceTests(unittest.TestCase):
         self.assertEqual(attributes["command"], "run_report")
         self.assertEqual(self.widget._user_attrs["command"], "run_report")
 
+    def test_saved_identity_gaps_never_reuse_an_existing_name(self):
+        old_counter = cw.createWidget.widgetId
+        old_names = cw.createWidget.widgetNameList
+        try:
+            cw.createWidget.widgetId = 0
+            cw.createWidget.widgetNameList = []
+
+            self.assertEqual(
+                cw.createWidget._allocate_identity("Widget10"), (10, "Widget10")
+            )
+            cw.createWidget.widgetNameList.append(["Widget10", "rootWidget", None, []])
+            self.assertEqual(
+                cw.createWidget._allocate_identity("Widget12"), (12, "Widget12")
+            )
+            cw.createWidget.widgetNameList.append(["Widget12", "rootWidget", None, []])
+            self.assertEqual(
+                cw.createWidget._allocate_identity("Widget13"), (13, "Widget13")
+            )
+            self.assertEqual(cw.createWidget.widgetId, 14)
+        finally:
+            cw.createWidget.widgetId = old_counter
+            cw.createWidget.widgetNameList = old_names
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tool_defaults.py
+++ b/tool_defaults.py
@@ -1,4 +1,4 @@
-"""Tool-wide Grid defaults and their JSON persistence."""
+"""Tool-wide geometry defaults and their JSON persistence."""
 
 from __future__ import annotations
 
@@ -9,7 +9,7 @@ from copy import deepcopy
 from typing import Any
 
 FILE_NAME = "tool_defaults.json"
-FORMAT_VERSION = 1
+FORMAT_VERSION = 2
 
 GRID_DEFAULTS: dict[str, Any] = {
     "gridRows": 25,
@@ -58,6 +58,34 @@ GRID_WIDGET_DEFAULTS: dict[str, dict[str, Any]] = {
     "sizegrip": {**_BASE_LAYOUT, "columnspan": 1, "sticky": "se"},
 }
 
+_BASE_PLACE_SIZE = {"width": 120, "height": 32}
+
+# Place defaults intentionally contain only dimensions.  The drop position is
+# always taken from the mouse pointer and therefore must not be a type default.
+PLACE_WIDGET_DEFAULTS: dict[str, dict[str, int]] = {
+    "default": deepcopy(_BASE_PLACE_SIZE),
+    "label": deepcopy(_BASE_PLACE_SIZE),
+    "button": {"width": 100, "height": 32},
+    "entry": {"width": 180, "height": 32},
+    "combobox": {"width": 180, "height": 32},
+    "spinbox": {"width": 140, "height": 32},
+    "checkbutton": {"width": 140, "height": 32},
+    "radiobutton": {"width": 140, "height": 32},
+    "scale": {"width": 200, "height": 32},
+    "progressbar": {"width": 200, "height": 24},
+    "separator": {"width": 200, "height": 8},
+    "canvas": {"width": 320, "height": 220},
+    "text": {"width": 320, "height": 220},
+    "listbox": {"width": 240, "height": 180},
+    "treeview": {"width": 320, "height": 220},
+    "frame": {"width": 320, "height": 220},
+    "labelframe": {"width": 320, "height": 220},
+    "panedwindow": {"width": 360, "height": 240},
+    "notebook": {"width": 360, "height": 240},
+    "scrollbar": {"width": 20, "height": 160},
+    "sizegrip": {"width": 24, "height": 24},
+}
+
 _INTEGER_LAYOUT_FIELDS = (
     "columnspan",
     "rowspan",
@@ -90,6 +118,41 @@ def default_path(program_name: str = "pytkgui") -> str:
     return os.path.join(config_home, program_name, FILE_NAME)
 
 
+def search_paths(
+    program_name: str = "pytkgui",
+    *,
+    current_directory: str | None = None,
+    module_directory: str | None = None,
+    user_path: str | None = None,
+    system_directory: str = "/etc",
+) -> list[str]:
+    """Return defaults files in increasing precedence order.
+
+    The shipped Python constants are the base.  JSON files are then layered
+    from the system installation, source/module directory, launch directory,
+    and finally the user's configuration directory.
+    """
+    module_directory = module_directory or os.path.dirname(os.path.abspath(__file__))
+    current_directory = current_directory or os.getcwd()
+    user_path = user_path or default_path(program_name)
+    candidates = [
+        os.path.join(system_directory, program_name, FILE_NAME),
+        os.path.join(module_directory, FILE_NAME),
+        os.path.join(current_directory, FILE_NAME),
+        user_path,
+    ]
+    result = []
+    seen = set()
+    for path in candidates:
+        absolute = os.path.abspath(path)
+        identity = os.path.normcase(absolute)
+        if identity in seen:
+            continue
+        seen.add(identity)
+        result.append(absolute)
+    return result
+
+
 def normalise_widget_layouts(
     value: Mapping[str, Any] | None,
 ) -> dict[str, dict[str, Any]]:
@@ -116,6 +179,29 @@ def normalise_widget_layouts(
     return layouts
 
 
+def normalise_place_widget_layouts(
+    value: Mapping[str, Any] | None,
+) -> dict[str, dict[str, int]]:
+    """Merge saved per-widget Place dimensions over the shipped table."""
+    layouts = deepcopy(PLACE_WIDGET_DEFAULTS)
+    if not isinstance(value, Mapping):
+        return layouts
+    for raw_name, raw_layout in value.items():
+        if not isinstance(raw_layout, Mapping):
+            continue
+        name = _widget_key(str(raw_name)) or "default"
+        base = deepcopy(layouts.get(name, layouts["default"]))
+        for field in ("width", "height"):
+            if field not in raw_layout:
+                continue
+            try:
+                base[field] = max(1, min(10000, int(raw_layout[field])))
+            except (TypeError, ValueError):
+                pass
+        layouts[name] = base
+    return layouts
+
+
 def normalise(data: Mapping[str, Any] | None) -> dict[str, Any]:
     """Return a complete, validated tool-defaults dictionary."""
     source = data if isinstance(data, Mapping) else {}
@@ -133,6 +219,9 @@ def normalise(data: Mapping[str, Any] | None) -> dict[str, Any]:
     result["gridWidgetDefaults"] = normalise_widget_layouts(
         source.get("gridWidgetDefaults")
     )
+    result["placeWidgetDefaults"] = normalise_place_widget_layouts(
+        source.get("placeWidgetDefaults")
+    )
     result["formatVersion"] = FORMAT_VERSION
     return result
 
@@ -146,6 +235,15 @@ def widget_layout(
     return deepcopy(table.get(_widget_key(widget_name), default))
 
 
+def place_size(
+    widget_name: str, layouts: Mapping[str, Mapping[str, Any]] | None = None
+) -> dict[str, int]:
+    """Return detached Place dimensions for one widget type."""
+    table = layouts if isinstance(layouts, Mapping) else PLACE_WIDGET_DEFAULTS
+    default = table.get("default", _BASE_PLACE_SIZE)
+    return deepcopy(table.get(_widget_key(widget_name), default))
+
+
 def read(path: str) -> dict[str, Any]:
     """Read defaults from *path*, returning shipped defaults when absent."""
     try:
@@ -155,10 +253,46 @@ def read(path: str) -> dict[str, Any]:
         return normalise(None)
 
 
+def _merge_mappings(
+    base: Mapping[str, Any], overrides: Mapping[str, Any]
+) -> dict[str, Any]:
+    """Recursively merge partial defaults without discarding sibling fields."""
+    merged = deepcopy(dict(base))
+    for key, value in overrides.items():
+        prior = merged.get(key)
+        if isinstance(prior, Mapping) and isinstance(value, Mapping):
+            merged[key] = _merge_mappings(prior, value)
+        else:
+            merged[key] = deepcopy(value)
+    return merged
+
+
+def read_discovered(
+    program_name: str = "pytkgui",
+    **path_options: Any,
+) -> tuple[dict[str, Any], list[str]]:
+    """Load and layer every valid defaults file found by :func:`search_paths`."""
+    merged: dict[str, Any] = {}
+    loaded_paths = []
+    for path in search_paths(program_name, **path_options):
+        try:
+            with open(path, "r", encoding="utf-8") as handle:
+                source = json.load(handle)
+        except (FileNotFoundError, json.JSONDecodeError, OSError, TypeError):
+            continue
+        if not isinstance(source, Mapping):
+            continue
+        merged = _merge_mappings(merged, source)
+        loaded_paths.append(path)
+    return normalise(merged), loaded_paths
+
+
 def write(path: str, data: Mapping[str, Any]) -> str:
     """Atomically write validated tool defaults and return *path*."""
     defaults = normalise(data)
-    os.makedirs(os.path.dirname(path), exist_ok=True)
+    directory = os.path.dirname(path)
+    if directory:
+        os.makedirs(directory, exist_ok=True)
     temporary = path + ".tmp"
     try:
         with open(temporary, "w", encoding="utf-8") as handle:
@@ -197,6 +331,28 @@ def update_widget_layout(
     defaults["gridWidgetDefaults"] = normalise_widget_layouts(
         {
             **defaults["gridWidgetDefaults"],
+            widget_key: layout,
+        }
+    )
+    return write(path, defaults)
+
+
+def update_place_widget_layout(
+    path: str,
+    widget_name: str,
+    layout: Mapping[str, Any],
+) -> str:
+    """Update one widget's Place dimensions without replacing other defaults."""
+    if os.path.isfile(path):
+        with open(path, "r", encoding="utf-8") as handle:
+            source = json.load(handle)
+    else:
+        source = {}
+    defaults = normalise(source)
+    widget_key = _widget_key(widget_name) or "default"
+    defaults["placeWidgetDefaults"] = normalise_place_widget_layouts(
+        {
+            **defaults["placeWidgetDefaults"],
             widget_key: layout,
         }
     )

--- a/tool_defaults.py
+++ b/tool_defaults.py
@@ -1,0 +1,176 @@
+"""Tool-wide Grid defaults and their JSON persistence."""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Mapping
+from copy import deepcopy
+from typing import Any
+
+FILE_NAME = "tool_defaults.json"
+FORMAT_VERSION = 1
+
+GRID_DEFAULTS: dict[str, Any] = {
+    "gridRows": 25,
+    "gridCols": 25,
+    "gridLineColor": "",
+    "gridRowMinsize": "2.5m",
+    "gridColMinsize": "5m",
+    "gridRowPad": "2.5m",
+    "gridColPad": "5m",
+}
+
+_BASE_LAYOUT = {
+    "columnspan": 2,
+    "rowspan": 1,
+    "padx": 2,
+    "pady": 2,
+    "ipadx": 0,
+    "ipady": 0,
+    "sticky": "nsew",
+}
+
+# These defaults deliberately use the names returned by fixWidgetName(), in
+# lower case. They are also written to tool_defaults.json so they can be tuned
+# without changing the application source.
+GRID_WIDGET_DEFAULTS: dict[str, dict[str, Any]] = {
+    "default": deepcopy(_BASE_LAYOUT),
+    "label": deepcopy(_BASE_LAYOUT),
+    "button": deepcopy(_BASE_LAYOUT),
+    "entry": {**_BASE_LAYOUT, "columnspan": 3},
+    "combobox": {**_BASE_LAYOUT, "columnspan": 3},
+    "spinbox": {**_BASE_LAYOUT, "columnspan": 3},
+    "checkbutton": deepcopy(_BASE_LAYOUT),
+    "radiobutton": deepcopy(_BASE_LAYOUT),
+    "scale": {**_BASE_LAYOUT, "columnspan": 4},
+    "progressbar": {**_BASE_LAYOUT, "columnspan": 4},
+    "separator": {**_BASE_LAYOUT, "columnspan": 4, "sticky": "ew"},
+    "canvas": {**_BASE_LAYOUT, "columnspan": 5, "rowspan": 5},
+    "text": {**_BASE_LAYOUT, "columnspan": 5, "rowspan": 5},
+    "listbox": {**_BASE_LAYOUT, "columnspan": 4, "rowspan": 5},
+    "treeview": {**_BASE_LAYOUT, "columnspan": 5, "rowspan": 5},
+    "frame": {**_BASE_LAYOUT, "columnspan": 5, "rowspan": 5},
+    "labelframe": {**_BASE_LAYOUT, "columnspan": 5, "rowspan": 5},
+    "panedwindow": {**_BASE_LAYOUT, "columnspan": 6, "rowspan": 5},
+    "notebook": {**_BASE_LAYOUT, "columnspan": 6, "rowspan": 5},
+    "scrollbar": {**_BASE_LAYOUT, "columnspan": 1, "rowspan": 4, "sticky": "ns"},
+    "sizegrip": {**_BASE_LAYOUT, "columnspan": 1, "sticky": "se"},
+}
+
+_INTEGER_LAYOUT_FIELDS = (
+    "columnspan",
+    "rowspan",
+    "padx",
+    "pady",
+    "ipadx",
+    "ipady",
+)
+
+
+def _widget_key(widget_name: str) -> str:
+    return (
+        str(widget_name)
+        .replace("ttk::", "")
+        .replace("tk::", "")
+        .replace("ttk.", "")
+        .replace("tk.", "")
+        .lower()
+    )
+
+
+def default_path(program_name: str = "pytkgui") -> str:
+    """Return the platform-appropriate tool_defaults.json path."""
+    if "APPDATA" in os.environ:
+        config_home = os.environ["APPDATA"]
+    elif "XDG_CONFIG_HOME" in os.environ:
+        config_home = os.environ["XDG_CONFIG_HOME"]
+    else:
+        config_home = os.path.join(os.environ["HOME"], ".config")
+    return os.path.join(config_home, program_name, FILE_NAME)
+
+
+def normalise_widget_layouts(
+    value: Mapping[str, Any] | None,
+) -> dict[str, dict[str, Any]]:
+    """Merge saved per-widget values over the shipped layout table."""
+    layouts = deepcopy(GRID_WIDGET_DEFAULTS)
+    if not isinstance(value, Mapping):
+        return layouts
+    for raw_name, raw_layout in value.items():
+        if not isinstance(raw_layout, Mapping):
+            continue
+        name = _widget_key(str(raw_name)) or "default"
+        base = deepcopy(layouts.get(name, layouts["default"]))
+        for field in _INTEGER_LAYOUT_FIELDS:
+            if field not in raw_layout:
+                continue
+            try:
+                minimum = 1 if field in ("columnspan", "rowspan") else 0
+                base[field] = max(minimum, int(raw_layout[field]))
+            except (TypeError, ValueError):
+                pass
+        if "sticky" in raw_layout:
+            base["sticky"] = str(raw_layout["sticky"])
+        layouts[name] = base
+    return layouts
+
+
+def normalise(data: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Return a complete, validated tool-defaults dictionary."""
+    source = data if isinstance(data, Mapping) else {}
+    result = deepcopy(GRID_DEFAULTS)
+    for name in ("gridRows", "gridCols"):
+        try:
+            result[name] = max(2, min(100, int(source.get(name, result[name]))))
+        except (TypeError, ValueError):
+            pass
+    result["gridLineColor"] = str(source.get("gridLineColor", "") or "")
+    for name in ("gridRowMinsize", "gridColMinsize", "gridRowPad", "gridColPad"):
+        value = str(source.get(name, result[name]) or "").strip()
+        if value:
+            result[name] = value
+    result["gridWidgetDefaults"] = normalise_widget_layouts(
+        source.get("gridWidgetDefaults")
+    )
+    result["formatVersion"] = FORMAT_VERSION
+    return result
+
+
+def widget_layout(
+    widget_name: str, layouts: Mapping[str, Mapping[str, Any]] | None = None
+) -> dict[str, Any]:
+    """Return a detached Grid layout record for one widget type."""
+    table = layouts if isinstance(layouts, Mapping) else GRID_WIDGET_DEFAULTS
+    default = table.get("default", _BASE_LAYOUT)
+    return deepcopy(table.get(_widget_key(widget_name), default))
+
+
+def read(path: str) -> dict[str, Any]:
+    """Read defaults from *path*, returning shipped defaults when absent."""
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            return normalise(json.load(handle))
+    except (FileNotFoundError, json.JSONDecodeError, OSError, TypeError):
+        return normalise(None)
+
+
+def write(path: str, data: Mapping[str, Any]) -> str:
+    """Atomically write validated tool defaults and return *path*."""
+    defaults = normalise(data)
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    temporary = path + ".tmp"
+    try:
+        with open(temporary, "w", encoding="utf-8") as handle:
+            json.dump(defaults, handle, indent=2)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary, path)
+    except (OSError, TypeError):
+        try:
+            if os.path.isfile(temporary):
+                os.unlink(temporary)
+        except OSError:
+            pass
+        raise
+    return path

--- a/tool_defaults.py
+++ b/tool_defaults.py
@@ -174,3 +174,30 @@ def write(path: str, data: Mapping[str, Any]) -> str:
             pass
         raise
     return path
+
+
+def update_widget_layout(
+    path: str,
+    widget_name: str,
+    layout: Mapping[str, Any],
+) -> str:
+    """Update one widget layout without replacing other on-disk defaults.
+
+    This intentionally reads the file again at save time. A project may have
+    its own Grid dimensions active in memory; saving a widget-type layout must
+    not write those project values over manually edited tool defaults.
+    """
+    if os.path.isfile(path):
+        with open(path, "r", encoding="utf-8") as handle:
+            source = json.load(handle)
+    else:
+        source = {}
+    defaults = normalise(source)
+    widget_key = _widget_key(widget_name) or "default"
+    defaults["gridWidgetDefaults"] = normalise_widget_layouts(
+        {
+            **defaults["gridWidgetDefaults"],
+            widget_key: layout,
+        }
+    )
+    return write(path, defaults)

--- a/undoredo.py
+++ b/undoredo.py
@@ -109,7 +109,7 @@ def restore_widget(snapshot: dict, mainFrame) -> Any | None:
         log.error("restore_widget: eval failed for %s: %s", widgetName, e)
         return None
 
-    w = cw.createWidget(mainFrame, widget)
+    w = cw.createWidget(mainFrame, widget, python_name=widgetName)
     project_format.remember_preserved_attributes(widget, widgetName, wDict)
 
     mgr = myVars.geomManager


### PR DESCRIPTION
## What changed

### Grid and responsive layout
- use the active ttk theme for the Grid canvas background and default guide colour
- add toolbar controls for drawn rows, columns, guide colour, `minsize`, and padding
- draw empty/new Grid projects immediately and keep the design frame synchronized with window resizing
- add type-specific Grid defaults for spans, padding, and `sticky`
- persist each container's actual internal Grid row/column counts and reproduce them during reload and code generation
- make Compact Grid use logical parents, close internal gaps, and trim trailing configured cells

### Place and project lifecycle
- add type-specific Place defaults containing only `width` and `height`
- allow the Layout popup to save current Place dimensions as the widget type's default
- clear all widget registries before rebuilding the canvas for a new project, preventing destroyed Tcl paths from leaking into Place re-parent/save operations
- skip unavailable widgets defensively during re-parenting and persistence
- always emit a zero attribute count for an unavailable widget
- report a detailed diagnostic for missing/invalid `WidgetN-KeyCount` values and continue without saved attributes instead of crashing in `range(None)`
- demote expected destroyed-widget cleanup messages and the callback-list diagnostic to debug logging

### Defaults and editing
- discover and layer `tool_defaults.json` from `/etc/pytkgui`, the source directory, the launch directory, and the user's platform configuration directory; built-in Python constants remain the base and the user file has highest priority
- merge partial nested Grid and Place widget defaults field by field
- preserve manually edited defaults when saving an individual widget type
- duplicate the Close/Help/Apply and Close/Apply/Save Default controls at both the top and bottom of their popups
- keep the attribute editor narrow and scrollable
- use the same ttkbootstrap colour chooser for Grid guides and widget colours

### Persistence and generated code
- restore saved `WidgetN` identities during construction instead of renaming auto-generated IDs later
- preserve callback and Tk-variable design names through save, reload, duplicate, and regeneration
- keep undo restoration on the original widget identity
- generate `<project-name>.py` in the last-used output directory
- format generated constructors and geometry calls as readable multiline Python
- preserve edited callback bodies in a previously generated file

### Documentation
- rewrite the README to describe the current palette, Grid and Place workflows, defaults precedence, JSON/backups, generated-code preservation, troubleshooting, and current limitations

## Root causes

Projects with non-contiguous widget IDs could create an auto-generated ID that already belonged to a previously restored widget. The subsequent rename then changed the wrong registry entry, allowing widgets to exchange saved parent/geometry records.

Compact Grid inspected physical Tk parents, but designer widgets share one physical master and use logical `in_` parents. Nested children were therefore mistaken for root widgets, and the command updated live Tk state without updating canonical Grid geometry.

The blank Grid startup had two related causes: empty-project loading returned before recreating the canvas window, and initial guide drawing sometimes ran before Tk assigned the canvas its final size.

Container reload compared persisted Tk type names such as `ttk::frame` with palette display names such as `Frame`. The project format also had no field for deliberately accumulated container tracks. `ContainerGrid` now records actual dimensions, with a 4×4 fallback for older projects.

The Place traceback came from `newProject()` destroying the old geometry frame while leaving the old widgets in `widgetList`, `widgetObjectList`, and `widgetNameList`. Later re-parent and save operations called Tk through those dead paths. New-project setup now destroys and clears widgets first, then rebuilds the canvas. Defensive guards stop malformed legacy state from cascading into code generation.

## Validation

- `python -m compileall -q .`
- `git diff --check`
- 27 unit tests passing, including JSON/callback round trips, non-contiguous IDs, Grid compaction, container dimensions, generated filenames/formatting, layered defaults, Place defaults, stale widgets, and invalid attribute counts
- the Git tree published to this branch exactly matches the tested local tree

A live GUI run is not available in the headless test container, so this remains a draft for desktop testing.